### PR TITLE
Update daily layout for all-day events

### DIFF
--- a/keep/src/main/resources/static/css/main/components/daily.css
+++ b/keep/src/main/resources/static/css/main/components/daily.css
@@ -19,6 +19,7 @@
   z-index: 20;
   display: grid;
   grid-template-columns: var(--time-column-width) 1fr;
+  grid-template-rows: auto auto;
   padding: 8px;
   background: #f9fafb;
   border-bottom: 1px solid #e5e7eb;
@@ -26,6 +27,8 @@
 
 /* "종일" 레이블 */
 .all-day-label {
+  grid-row: 1;
+  grid-column: 1;
   flex: 0 0 var(--time-column-width);
   display: flex;
   align-items: center;
@@ -37,6 +40,8 @@
 
 /* 종일 이벤트 카드 리스트 */
 .events-all-day-list {
+  grid-row: 1;
+  grid-column: 2;
   position: relative;
   height: calc(var(--all-day-row-height) * 2);
 }
@@ -81,7 +86,8 @@
 
 /* +더보기 버튼 (종일) */
 .all-day-toggle {
-  grid-column: 1 / 2;
+  grid-row: 2;
+  grid-column: 1;
   justify-self: start;
   margin-top: 4px;
   padding: 4px 8px;

--- a/keep/src/main/resources/templates/main/components/daily.html
+++ b/keep/src/main/resources/templates/main/components/daily.html
@@ -5,13 +5,13 @@
 <!-- templates/main/components/daily.html -->
 <div th:fragment="content" class="daily-schedule-container">
 	<!-- 종일 이벤트 영역 -->
-	<div class="events-all-day-wrapper">
-		<div class="all-day-label">종일</div>
-		<div class="events-all-day-list">
-			<!-- 종일 이벤트 카드들이 렌더링됩니다 (최대 10개까지) -->
-		</div>
-		<button class="all-day-toggle">+ 더보기</button>
-	</div>
+        <div class="events-all-day-wrapper">
+                <div class="all-day-label">종일</div>
+                <div class="events-all-day-list">
+                        <!-- 종일 이벤트 카드들 -->
+                </div>
+                <button class="all-day-toggle">+ 더보기</button>
+        </div>
 
 	<!-- 일반 일정 영역 -->
 	<div class="daily-schedule">


### PR DESCRIPTION
## Summary
- adjust `daily.css` grid layout so all-day events mirror weekly view
- clean up all-day markup and comments in `daily.html`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847744ce78c8327b47d4406c02e8b89