### PR TITLE
Fix weekly event spacing

### DIFF
--- a/keep/src/main/resources/static/css/main/components/weekly.css
+++ b/keep/src/main/resources/static/css/main/components/weekly.css
@@ -234,6 +234,14 @@
   font-size: 0.875rem;
   color: #fff;
   cursor: pointer;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.event.show {
+  opacity: 1;
+  transform: none;
 }
 
 /* — 전체 컨테이너 — */


### PR DESCRIPTION
## Summary
- revise weekly events layout to size by overlapping groups
- add vertical spacing matching horizontal gap
- fade in weekly event cards on render

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68478c5f9a008327abb586cdcf2bb5f4