### PR TITLE
Fix sticky header overlap

### DIFF
--- a/keep/src/main/resources/static/css/main/components/daily.css
+++ b/keep/src/main/resources/static/css/main/components/daily.css
@@ -12,12 +12,14 @@
         /* 주간 뷰와 동일한 레이아웃을 위해 추가 */
         --weekday-header-height: 40px;
         --time-column-width: 60px;
+        /* 대시보드 헤더 높이(스크롤 고정 offset) */
+        --dashboard-header-height: 60px;
 }
 
 /* 종일 이벤트 영역 */
 .events-all-day-wrapper {
         position: sticky;
-        top: var(--weekday-header-height);
+        top: calc(var(--dashboard-header-height) + var(--weekday-header-height));
         z-index: 20;
         display: grid;
         grid-template-columns: var(--time-column-width) 1fr;

--- a/keep/src/main/resources/static/css/main/components/weekly.css
+++ b/keep/src/main/resources/static/css/main/components/weekly.css
@@ -13,12 +13,14 @@
   --weekday-header-height: 40px;
   /* 시간축(왼쪽) 컬럼 너비 */
   --time-column-width: 60px;
+  /* 대시보드 헤더 높이(스크롤 고정 offset) */
+  --dashboard-header-height: 60px;
 }
 
 /* — 요일 헤더 — */
 .weekday-header {
   position: sticky;
-  top: 0;
+  top: var(--dashboard-header-height);
   z-index: 30;
   display: grid;
   /* 좌측 시간축(60px) + (나머지 너비를 7등분) */
@@ -68,7 +70,7 @@
 /* — 종일 이벤트 영역 — */
 .events-all-day-wrapper {
   position: sticky;
-  top: var(--weekday-header-height);
+  top: calc(var(--dashboard-header-height) + var(--weekday-header-height));
   z-index: 20;
   display: grid;
   grid-template-columns: var(--time-column-width) 1fr;

--- a/keep/src/main/resources/static/js/main/dashboard.js
+++ b/keep/src/main/resources/static/js/main/dashboard.js
@@ -1,6 +1,10 @@
 // static/js/main/dashboard.js
 document.addEventListener('DOMContentLoaded', () => {
-	let dateInput = document.getElementById('current-date');
+        const headerEl = document.querySelector('.dashboard-header');
+        if (headerEl) {
+                document.documentElement.style.setProperty('--dashboard-header-height', `${headerEl.offsetHeight}px`);
+        }
+        let dateInput = document.getElementById('current-date');
 	if (!dateInput) {
 		return;
 	}


### PR DESCRIPTION
## Summary
- add dashboard header variable in daily/weekly styles
- offset weekly and daily sticky elements by dashboard header
- set sticky offset dynamically in dashboard.js

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684799b519c88327a00e4483a83fdd01