### PR TITLE
Fix drag area leftover on pointer cancel

### DIFF
--- a/keep/src/main/resources/static/js/main/components/daily.js
+++ b/keep/src/main/resources/static/js/main/components/daily.js
@@ -28,8 +28,9 @@
 
 	function onDrop(e) {
 		e.preventDefault();
-		document.removeEventListener('pointermove', onDrag);
-		document.removeEventListener('pointerup', onDrop);
+                document.removeEventListener('pointermove', onDrag);
+                document.removeEventListener('pointerup', onDrop);
+                document.removeEventListener('pointercancel', onDrop);
 
 		if (isDragging) {
 			const snappedTop = parseFloat(draggingEvt.style.top);
@@ -106,9 +107,10 @@
 			startY = e.clientY;
 			origTop = parseFloat(getComputedStyle(evEl).top);
 
-			document.addEventListener('pointermove', onDrag);
-			document.addEventListener('pointerup', onDrop);
-		});
+                        document.addEventListener('pointermove', onDrag);
+                        document.addEventListener('pointerup', onDrop);
+                        document.addEventListener('pointercancel', onDrop);
+                });
 	}
 
 	function renderAllDayEvents(allDayEvents, dateStr) {
@@ -319,15 +321,17 @@
                         if (!selecting) return;
                         document.removeEventListener('pointermove', pointerMove);
                         document.removeEventListener('pointerup', pointerUp);
+                        document.removeEventListener('pointercancel', cancelSelection);
                         if (selectDiv) selectDiv.remove();
                         selecting = false;
                 }
 
 		function pointerUp(eUp) {
 			if (!selecting) return;
-			document.removeEventListener('pointermove', pointerMove);
-			document.removeEventListener('pointerup', pointerUp);
-			const cur = eUp.clientY - grid.getBoundingClientRect().top;
+                        document.removeEventListener('pointermove', pointerMove);
+                        document.removeEventListener('pointerup', pointerUp);
+                        document.removeEventListener('pointercancel', cancelSelection);
+                        const cur = eUp.clientY - grid.getBoundingClientRect().top;
 			let top = Math.min(startY, cur);
 			let bottom = Math.max(startY, cur);
 			top = Math.max(0, Math.round(top / STEP) * STEP);
@@ -349,6 +353,7 @@
                         grid.appendChild(selectDiv);
                         document.addEventListener('pointermove', pointerMove);
                         document.addEventListener('pointerup', pointerUp);
+                        document.addEventListener('pointercancel', cancelSelection);
                 });
 
                 grid.addEventListener('contextmenu', e => {

--- a/keep/src/main/resources/static/js/main/components/weekly.js
+++ b/keep/src/main/resources/static/js/main/components/weekly.js
@@ -582,15 +582,17 @@
                         if (!selecting) return;
                         document.removeEventListener('pointermove', pointerMove);
                         document.removeEventListener('pointerup', pointerUp);
+                        document.removeEventListener('pointercancel', cancelSelection);
                         if (selectDiv) selectDiv.remove();
                         selecting = false;
                 }
 
 		function pointerUp(eUp) {
 			if (!selecting) return;
-			document.removeEventListener('pointermove', pointerMove);
-			document.removeEventListener('pointerup', pointerUp);
-			const rect = grid.getBoundingClientRect();
+                        document.removeEventListener('pointermove', pointerMove);
+                        document.removeEventListener('pointerup', pointerUp);
+                        document.removeEventListener('pointercancel', cancelSelection);
+                        const rect = grid.getBoundingClientRect();
 			const curY = eUp.clientY - rect.top;
 			const curX = eUp.clientX - rect.left;
 			const colIdx = Math.floor(curX / (rect.width / 7));
@@ -628,6 +630,7 @@
 
                         document.addEventListener('pointermove', pointerMove);
                         document.addEventListener('pointerup', pointerUp);
+                        document.addEventListener('pointercancel', cancelSelection);
                 });
 
                 grid.addEventListener('contextmenu', e => {


### PR DESCRIPTION
## Summary
- ensure daily drag-and-drop removes overlay on pointer cancel
- clean up drag selection overlays on pointer cancel in daily and weekly views

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847c9055c088327bd9dd5329b7ae594