### PR TITLE
Improve daily schedule view

### DIFF
--- a/keep/src/main/resources/static/css/main/components/daily.css
+++ b/keep/src/main/resources/static/css/main/components/daily.css
@@ -2,6 +2,8 @@
 :root {
         /* 시간 슬롯 높이 */
         --hour-height: 60px;
+        /* 맨 밑 "다음 날 00시" 슬롯 높이 */
+        --bottom-slot-height: 40px;
         /* 종일 이벤트 카드 최소 너비 */
         --all-day-card-width: 150px;
         /* 종일 이벤트 한 줄 높이 */
@@ -19,7 +21,7 @@
 /* 종일 이벤트 영역 */
 .events-all-day-wrapper {
         position: sticky;
-        top: calc(var(--dashboard-header-height) + var(--weekday-header-height));
+        top: var(--dashboard-header-height);
         z-index: 20;
         display: grid;
         grid-template-columns: var(--time-column-width) 1fr;
@@ -105,10 +107,13 @@
 }
 
 .hour-label {
-	position: relative;
-	height: var(--hour-height);
-	box-sizing: border-box;
-	border-bottom: 1px solid #e5e7eb;
+        position: relative;
+        height: var(--hour-height);
+        box-sizing: border-box;
+        border-bottom: 1px solid #e5e7eb;
+}
+.hour-label:last-child {
+        height: var(--bottom-slot-height);
 }
 
 .hour-text {
@@ -126,13 +131,19 @@
 	position: relative;
 	background: #fff;
 	overflow: hidden;
-	height: calc(24 * var(--hour-height));
+        height: calc((24 * var(--hour-height)) + var(--bottom-slot-height));
 }
 
 .hour-slot {
-	height: var(--hour-height);
-	border-bottom: 1px solid #e5e7eb;
-	box-sizing: border-box;
+        height: var(--hour-height);
+        border-bottom: 1px solid #e5e7eb;
+        box-sizing: border-box;
+}
+.hour-slot:last-child {
+        height: var(--bottom-slot-height);
+}
+.hour-slot:not(:last-child):hover {
+        background: rgba(59, 130, 246, 0.1);
 }
 
 /* 일반 이벤트 컨테이너 */

--- a/keep/src/main/resources/static/css/main/components/weekly.css
+++ b/keep/src/main/resources/static/css/main/components/weekly.css
@@ -214,6 +214,9 @@
   box-sizing: border-box;
   /* 높이는 grid-template-rows에 의해 자동 적용 */
 }
+.hour-slot:nth-last-child(n+8):hover {
+  background: rgba(59, 130, 246, 0.1);
+}
 
 /* 이벤트 블록이 위치할 컨테이너 */
 .events-container {

--- a/keep/src/main/resources/templates/main/components/daily.html
+++ b/keep/src/main/resources/templates/main/components/daily.html
@@ -15,19 +15,19 @@
 	<!-- 일반 일정 영역 -->
 	<div class="daily-schedule">
 		<!-- 시간축 -->
-		<div class="time-column">
-			<div class="hour-label" th:each="h : ${#numbers.sequence(0,23)}">
-				<span class="hour-text"
-					th:text="${h < 12
+                <div class="time-column">
+                        <div class="hour-label" th:each="h : ${#numbers.sequence(0,24)}">
+                                <span class="hour-text"
+                                        th:text="${h < 12
                        ? '오전 ' + (h==0?12:h) + '시'
                        : '오후 ' + ((h-12)==0?12:(h-12)) + '시'}">
-					오전 12시 </span>
-			</div>
-		</div>
+                                        오전 12시 </span>
+                        </div>
+                </div>
 
 		<!-- 스케줄 그리드 -->
-		<div class="schedule-grid" id ="chedule-grid">
-			<div class="hour-slot" th:each="h : ${#numbers.sequence(0,23)}"></div>
+                <div class="schedule-grid" id ="chedule-grid">
+                        <div class="hour-slot" th:each="h : ${#numbers.sequence(0,24)}"></div>
 			<div class="events-container">
 				<!-- 일간 이벤크 카드들이 렌더링됩니다. -->
 			</div>


### PR DESCRIPTION
## Summary
- keep all-day section under dashboard header when scrolling in daily view
- extend daily timeline to show next day's midnight
- match last row height to weekly view
- highlight hourly slots when hovering (excludes last row)
- apply the hover highlight to weekly view as well

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847cf9969e4832781c9651013850dcb