### PR TITLE
Implement current time line improvements

### DIFF
--- a/keep/src/main/resources/static/js/main/components/daily.js
+++ b/keep/src/main/resources/static/js/main/components/daily.js
@@ -248,6 +248,7 @@
 
 		const container = grid.querySelector('.events-container');
 		container.innerHTML = '';
+                updateCurrentTimeLine();
 		const H = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--hour-height'));
 		const GAP = 2;
 
@@ -269,9 +270,21 @@
                         div.innerHTML = `<span class="event-title">${evt.title}</span>`;
                         container.appendChild(div);
                 });
-		initDragAndDrop();
-		attachGridClick();
-	}
+                initDragAndDrop();
+                attachGridClick();
+        }
+
+        function updateCurrentTimeLine() {
+                const line = document.querySelector('.current-time-line');
+                if (!line) return;
+                const now = new Date();
+                const h = now.getHours() + now.getMinutes() / 60;
+                const H = parseFloat(getComputedStyle(document.documentElement)
+                        .getPropertyValue('--hour-height'));
+                line.style.top = `${h * H}px`;
+                const pad = n => String(n).padStart(2, '0');
+                line.dataset.time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+        }
 
 	function attachGridClick() {
 		const grid = document.querySelector('.schedule-grid');
@@ -359,6 +372,9 @@
                         if (e.target.closest('.event')) return;
                         const slot = e.target.closest('.hour-slot');
                         if (!slot) return;
+                        const hourSlots = Array.from(grid.querySelectorAll('.hour-slot'));
+                        const idx = hourSlots.indexOf(slot);
+                        if (idx === hourSlots.length - 1) return;
                         selecting = true;
                         startY = e.clientY - grid.getBoundingClientRect().top;
                         selectDiv = document.createElement('div');

--- a/keep/src/main/resources/static/js/main/components/weekly.js
+++ b/keep/src/main/resources/static/js/main/components/weekly.js
@@ -495,16 +495,39 @@
 	}
 
 	// 현재 시간선 위치 및 헤더의 날짜 숫자 업데이트
-	function updateCurrentTimeLine() {
-		const line = document.querySelector('.current-time-line');
-		const now = new Date();
-		const h = now.getHours() + now.getMinutes() / 60;
-		const slotHeight = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
-		);
-		line.style.top = `${h * slotHeight}px`;
-		updateWeekDateNumbers();
-	}
+        function updateCurrentTimeLine() {
+                const line = document.querySelector('.current-time-line');
+                if (!line) return;
+                const now = new Date();
+                const h = now.getHours() + now.getMinutes() / 60;
+                const slotHeight = parseFloat(
+                        getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
+                );
+                line.style.top = `${h * slotHeight}px`;
+
+                const currentDateInput = document.getElementById('current-date');
+                const selectedDate = new Date(currentDateInput.dataset.selectDate);
+                const weekStart = new Date(selectedDate);
+                weekStart.setDate(selectedDate.getDate() - selectedDate.getDay());
+
+                const todayMid = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+                const diff = Math.floor((todayMid - new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate())) / 86400000);
+
+                const pct = 100 / 7;
+                if (diff < 0 || diff > 6) {
+                        line.style.display = 'none';
+                } else {
+                        line.style.display = '';
+                        line.style.left = `calc(${diff * pct}% )`;
+                        line.style.width = `calc(${pct}% )`;
+                        line.style.right = 'auto';
+                }
+
+                const pad = n => String(n).padStart(2, '0');
+                line.dataset.time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+
+                updateWeekDateNumbers();
+        }
 
 	// 요일 헤더의 .date-number에 실제 날짜(숫자) 채우기
 	function updateWeekDateNumbers() {


### PR DESCRIPTION
## Summary
- limit weekly current time line to today's column
- show tooltip with time on hover in weekly view
- display current time line in daily view
- prevent selecting the bottom dummy slot in daily grid

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a11f847a883279105a8525e89f28d