### PR TITLE
Fix modal cancel blocking drag

### DIFF
--- a/keep/src/main/resources/static/js/main/components/daily.js
+++ b/keep/src/main/resources/static/js/main/components/daily.js
@@ -392,6 +392,8 @@
                         cancelSelection();
                 });
 
+                document.addEventListener('scheduleModalClosed', cancelSelection);
+
                 grid.addEventListener('click', e => {
                         if (selecting) return; // drag selection handled separately
                         const slot = e.target.closest('.hour-slot');

--- a/keep/src/main/resources/static/js/main/components/modal/schedule-modal.js
+++ b/keep/src/main/resources/static/js/main/components/modal/schedule-modal.js
@@ -177,13 +177,14 @@
 			?.classList.add('selected');
 	}
 
-	function closeModal() {
-		document.getElementById('schedule-modal-overlay').classList.add('hidden');
-		document.getElementById('schedule-modal').classList.add('hidden');
-		document.getElementById('schedule-form').reset();
-		document.getElementById('sched-id').value = '';
-		document.querySelectorAll('.cat-color').forEach(b => b.classList.remove('selected'));
-	}
+        function closeModal() {
+                document.getElementById('schedule-modal-overlay').classList.add('hidden');
+                document.getElementById('schedule-modal').classList.add('hidden');
+                document.getElementById('schedule-form').reset();
+                document.getElementById('sched-id').value = '';
+                document.querySelectorAll('.cat-color').forEach(b => b.classList.remove('selected'));
+                document.dispatchEvent(new Event('scheduleModalClosed'));
+        }
 
 	// 전역 호출용 및 초기화
 	window.initScheduleModal = initScheduleModal;

--- a/keep/src/main/resources/static/js/main/components/weekly.js
+++ b/keep/src/main/resources/static/js/main/components/weekly.js
@@ -677,6 +677,8 @@
                         cancelSelection();
                 });
 
+                document.addEventListener('scheduleModalClosed', cancelSelection);
+
                 grid.addEventListener('click', e => {
                         if (selecting) return; // drag selection handled separately
                         const slot = e.target.closest('.hour-slot');


### PR DESCRIPTION
## Summary
- reset selection state when modal closes
- dispatch close event from schedule modal

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a17fae3a88327b82794ddefcc4d03