### PR TITLE
Add monthly range events and more list modal

### DIFF
--- a/keep/src/main/resources/static/css/main/components/modal/monthly-more-modal.css
+++ b/keep/src/main/resources/static/css/main/components/modal/monthly-more-modal.css
@@ -1,0 +1,50 @@
+:root {
+  --more-modal-width: 260px;
+}
+
+#monthly-more-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--more-modal-width);
+  height: 100%;
+  background: #fff;
+  box-shadow: 2px 0 6px rgba(0,0,0,0.1);
+  padding: 1rem;
+  overflow-y: auto;
+  z-index: 101;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+}
+
+#monthly-more-modal.show {
+  transform: translateX(0);
+}
+
+#monthly-more-modal.hidden {
+  display: none;
+}
+
+#monthly-more-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+#monthly-more-list li {
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  border-left-width: 4px;
+  border-left-style: solid;
+}
+
+#monthly-more-close {
+  display: block;
+  width: 100%;
+  padding: 6px 0;
+  background: #f3f4f6;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
+++ b/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
@@ -1,0 +1,46 @@
+(function() {
+  function init() {
+    const overlay = document.getElementById('monthly-more-overlay');
+    const modal = document.getElementById('monthly-more-modal');
+    const closeBtn = document.getElementById('monthly-more-close');
+    if (!overlay || !modal || !closeBtn) return;
+
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', closeModal);
+  }
+
+  function openModal(events) {
+    const overlay = document.getElementById('monthly-more-overlay');
+    const modal = document.getElementById('monthly-more-modal');
+    const list = document.getElementById('monthly-more-list');
+    if (!overlay || !modal || !list) return;
+    list.innerHTML = '';
+    events.forEach(e => {
+      const li = document.createElement('li');
+      li.textContent = e.title;
+      li.style.borderLeft = `4px solid ${e.category}`;
+      li.dataset.id = e.schedulesId;
+      li.addEventListener('click', () => {
+        if (window.loadAndOpenScheduleModal) {
+          window.loadAndOpenScheduleModal(e.schedulesId);
+        }
+      });
+      list.appendChild(li);
+    });
+    overlay.classList.remove('hidden');
+    modal.classList.add('show');
+    modal.classList.remove('hidden');
+  }
+
+  function closeModal() {
+    const overlay = document.getElementById('monthly-more-overlay');
+    const modal = document.getElementById('monthly-more-modal');
+    if (!overlay || !modal) return;
+    modal.classList.remove('show');
+    modal.addEventListener('transitionend', () => modal.classList.add('hidden'), { once: true });
+    overlay.classList.add('hidden');
+  }
+
+  window.initMonthlyMoreModal = init;
+  window.openMonthlyMoreModal = openModal;
+})();

--- a/keep/src/main/resources/static/js/main/components/monthly.js
+++ b/keep/src/main/resources/static/js/main/components/monthly.js
@@ -35,9 +35,18 @@
 
     const eventMap = {};
     events.forEach(e => {
-      const d = new Date(e.startTs).getDate();
-      if (!eventMap[d]) eventMap[d] = [];
-      eventMap[d].push(e);
+      const start = new Date(e.startTs);
+      const end = new Date(e.endTs);
+      const cur = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+      const last = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+      while (cur <= last) {
+        if (cur.getMonth() === month) {
+          const d = cur.getDate();
+          if (!eventMap[d]) eventMap[d] = [];
+          eventMap[d].push(e);
+        }
+        cur.setDate(cur.getDate() + 1);
+      }
     });
 
     // fill blanks before first day
@@ -90,6 +99,12 @@
       const more = document.createElement('div');
       more.className = 'more-link';
       more.textContent = `+${events.length - MAX}`;
+      more.addEventListener('click', e => {
+        e.stopPropagation();
+        if (window.openMonthlyMoreModal) {
+          window.openMonthlyMoreModal(events);
+        }
+      });
       list.appendChild(more);
     }
     cell.appendChild(list);

--- a/keep/src/main/resources/static/js/main/dashboard.js
+++ b/keep/src/main/resources/static/js/main/dashboard.js
@@ -119,6 +119,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					}
 				}
                                 window.initScheduleModal();
+                                if (window.initMonthlyMoreModal) {
+                                        window.initMonthlyMoreModal();
+                                }
                                 requestAnimationFrame(() => {
                                         fragmentContainer.style.opacity = 1;
                                 });

--- a/keep/src/main/resources/templates/main/components/modal/monthly-more-modal.html
+++ b/keep/src/main/resources/templates/main/components/modal/monthly-more-modal.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<div th:fragment="monthly-more-modal">
+  <div id="monthly-more-overlay" class="modal-overlay hidden"></div>
+  <div id="monthly-more-modal" class="hidden">
+    <h3 class="modal-title">일정 목록</h3>
+    <ul id="monthly-more-list"></ul>
+    <button id="monthly-more-close" type="button">닫기</button>
+  </div>
+</div>
+</html>

--- a/keep/src/main/resources/templates/main/dashboard.html
+++ b/keep/src/main/resources/templates/main/dashboard.html
@@ -16,6 +16,7 @@
 
         <link rel="stylesheet" th:href="@{/css/main/components/modal/schedule-modal.css}" />
         <link rel="stylesheet" th:href="@{/css/main/components/modal/save-toast.css}" />
+        <link rel="stylesheet" th:href="@{/css/main/components/modal/monthly-more-modal.css}" />
 </th:block>
 <!--/* content */-->
 <th:block layout:fragment="content">
@@ -44,6 +45,7 @@
              <div th:replace="~{main/components/modal/schedule-modal :: schedule-modal}"></div>
              <div th:replace="~{common/calendar-modal :: calendar-modal}"></div>
              <div th:replace="~{main/components/modal/save-toast :: save-toast}"></div>
+             <div th:replace="~{main/components/modal/monthly-more-modal :: monthly-more-modal}"></div>
 
 </th:block>
 <!--/* script */-->
@@ -55,6 +57,7 @@
         <script th:src="@{/js/main/components/monthly.js}"></script>
         <script th:src="@{/js/main/components/modal/schedule-modal.js}"></script>
         <script th:src="@{/js/main/components/save-toast.js}"></script>
+        <script th:src="@{/js/main/components/modal/monthly-more-modal.js}"></script>
 </th:block>
 
 </html>


### PR DESCRIPTION
## Summary
- expand monthly schedule rendering to include entire date ranges
- show left-side modal listing events when day has more items
- hook modal initialization in dashboard

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a241ca26083279729a2f157a0e909