### PR TITLE
Handle multi-day events in monthly view

### DIFF
--- a/keep/src/main/resources/static/css/main/components/modal/schedule-modal.css
+++ b/keep/src/main/resources/static/css/main/components/modal/schedule-modal.css
@@ -10,6 +10,11 @@
   background: rgba(0,0,0,0.3);
   z-index: 100;
 }
+
+/* 일정 등록 모달은 다른 모달보다 위에 표시 */
+#schedule-modal-overlay {
+  z-index: 200;
+}
 .modal-overlay.hidden {
   display: none;
 }
@@ -28,6 +33,11 @@
 }
 .modal.hidden {
   display: none;
+}
+
+/* 일정 등록 모달 상자 z-index 조정 */
+#schedule-modal {
+  z-index: 201;
 }
 
 .modal-title {

--- a/keep/src/main/resources/static/css/main/components/monthly.css
+++ b/keep/src/main/resources/static/css/main/components/monthly.css
@@ -3,12 +3,27 @@
 }
 
 .monthly-calendar {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   grid-auto-rows: var(--monthly-cell-height);
   border-top: 1px solid #e5e7eb;
   border-left: 1px solid #e5e7eb;
   background: #fff;
+}
+
+.monthly-events-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.monthly-events-overlay .event-bar {
+  position: absolute;
+  pointer-events: auto;
+  box-sizing: border-box;
 }
 
 .monthly-calendar .day-cell {

--- a/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
+++ b/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
@@ -30,6 +30,7 @@
     overlay.classList.remove('hidden');
     modal.classList.add('show');
     modal.classList.remove('hidden');
+    document.addEventListener('scheduleModalClosed', closeModal);
   }
 
   function closeModal() {
@@ -39,6 +40,7 @@
     modal.classList.remove('show');
     modal.addEventListener('transitionend', () => modal.classList.add('hidden'), { once: true });
     overlay.classList.add('hidden');
+    document.removeEventListener('scheduleModalClosed', closeModal);
   }
 
   window.initMonthlyMoreModal = init;


### PR DESCRIPTION
## Summary
- show multi-day schedules as one bar spanning days
- ensure schedule modal overlays more list
- close more list when schedule modal closes

## Testing
- `./gradlew test` *(fails: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_684a26e662ec8327b335e186604f2a86