### PR TITLE
Enable dragging in monthly calendar

### DIFF
--- a/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
+++ b/keep/src/main/resources/static/js/main/components/modal/monthly-more-modal.js
@@ -30,7 +30,6 @@
     overlay.classList.remove('hidden');
     modal.classList.add('show');
     modal.classList.remove('hidden');
-    document.addEventListener('scheduleModalClosed', closeModal);
   }
 
   function closeModal() {
@@ -40,7 +39,6 @@
     modal.classList.remove('show');
     modal.addEventListener('transitionend', () => modal.classList.add('hidden'), { once: true });
     overlay.classList.add('hidden');
-    document.removeEventListener('scheduleModalClosed', closeModal);
   }
 
   window.initMonthlyMoreModal = init;


### PR DESCRIPTION
## Summary
- keep monthly-more modal open when schedule modal closes
- allow multi-day events to be dragged on monthly view
- support opening schedule modal by dragging across empty cells

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a297b1a4883278e9463bbf35315fa