### PR TITLE
Add adjacent month days and adjust monthly event rendering

### DIFF
--- a/keep/src/main/resources/static/css/main/components/monthly.css
+++ b/keep/src/main/resources/static/css/main/components/monthly.css
@@ -34,6 +34,14 @@
   overflow: hidden;
 }
 
+.monthly-calendar .day-cell.other-month {
+  background: #f3f4f6;
+}
+
+.monthly-calendar .day-cell.other-month .day-number {
+  color: #9ca3af;
+}
+
 .monthly-calendar .day-number {
   position: absolute;
   top: 2px;


### PR DESCRIPTION
## Summary
- show previous and next month days in monthly view with dimmed background
- display multi-day events starting each week within day cells
- avoid overlap between multi-day bars and day events
- make drag ghost follow bar element

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a2f43cf5883278bbd017ee7708c65