### PR TITLE
Fix monthly overlay event duplication

### DIFF
--- a/keep/src/main/resources/static/css/main/components/monthly.css
+++ b/keep/src/main/resources/static/css/main/components/monthly.css
@@ -19,6 +19,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+  z-index: 1;
 }
 .monthly-events-overlay .event-bar {
   position: absolute;
@@ -48,6 +49,7 @@
   right: 4px;
   font-size: 0.75rem;
   color: #555;
+  z-index: 2;
 }
 
 .monthly-calendar .day-cell.sun .day-number,

--- a/keep/src/main/resources/static/js/main/components/monthly.js
+++ b/keep/src/main/resources/static/js/main/components/monthly.js
@@ -87,30 +87,31 @@
       const end = new Date(eDate.getFullYear(), eDate.getMonth(), eDate.getDate());
       if (end < displayStart || start > displayEnd) return;
 
-      // Only put single-day events into dayMap to avoid duplicate rendering
-      if (start.getTime() === end.getTime()) {
+      const isSingleDay = start.getTime() === end.getTime();
+
+      if (isSingleDay) {
         const firstVisible = start < displayStart ? displayStart : start;
         const key = formatYMD(firstVisible);
         if (!dayMap[key]) dayMap[key] = [];
         dayMap[key].push(e);
-      }
-
-      let segStart = start < displayStart ? displayStart : start;
-      const realEnd = end > displayEnd ? displayEnd : end;
-      while (segStart <= realEnd) {
-        const weekEnd = new Date(segStart);
-        weekEnd.setDate(segStart.getDate() + (6 - weekEnd.getDay()));
-        const segEnd = weekEnd < realEnd ? weekEnd : realEnd;
-        segments.push({
-          id: e.schedulesId,
-          title: e.title,
-          category: e.category,
-          start: new Date(segStart),
-          end: new Date(segEnd),
-          eventStart: start
-        });
-        segStart = new Date(segEnd);
-        segStart.setDate(segStart.getDate() + 1);
+      } else {
+        let segStart = start < displayStart ? displayStart : start;
+        const realEnd = end > displayEnd ? displayEnd : end;
+        while (segStart <= realEnd) {
+          const weekEnd = new Date(segStart);
+          weekEnd.setDate(segStart.getDate() + (6 - weekEnd.getDay()));
+          const segEnd = weekEnd < realEnd ? weekEnd : realEnd;
+          segments.push({
+            id: e.schedulesId,
+            title: e.title,
+            category: e.category,
+            start: new Date(segStart),
+            end: new Date(segEnd),
+            eventStart: start
+          });
+          segStart = new Date(segEnd);
+          segStart.setDate(segStart.getDate() + 1);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- avoid creating overlay segments for single-day events
- keep day numbers visible over monthly overlay

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a656eb0708327941cec28b5be98ea