### PR TITLE
Fix monthly calendar more link placement and event order

### DIFF
--- a/keep/src/main/resources/static/css/main/components/monthly.css
+++ b/keep/src/main/resources/static/css/main/components/monthly.css
@@ -58,9 +58,14 @@
 }
 
 .monthly-calendar .events-container {
-  margin-top: 22px;
+  position: absolute;
+  top: 22px;
+  bottom: 2px;
+  left: 2px;
+  right: 2px;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   gap: 2px;
 }
 

--- a/keep/src/main/resources/static/js/main/components/monthly.js
+++ b/keep/src/main/resources/static/js/main/components/monthly.js
@@ -224,7 +224,12 @@
 
     const sorted = events
       .map(e => ({ ...e, start: new Date(e.startTs), end: new Date(e.endTs) }))
-      .sort((a, b) => a.start - b.start);
+      .sort((a, b) => {
+        const durA = Math.ceil((a.end - a.start) / 86400000);
+        const durB = Math.ceil((b.end - b.start) / 86400000);
+        if (durA !== durB) return durB - durA;
+        return a.start - b.start;
+      });
 
     sorted.forEach(evt => {
       let s = evt.start;


### PR DESCRIPTION
## Summary
- position the monthly more link at the bottom of the cell
- sort monthly events so multi-day events appear first

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a7bd8e8a083278fbec14c4f676e01