### PR TITLE
Add error display in toast

### DIFF
--- a/keep/src/main/resources/static/js/main/components/save-toast.js
+++ b/keep/src/main/resources/static/js/main/components/save-toast.js
@@ -4,9 +4,17 @@
 	const undoBtn = document.getElementById('save-toast-undo');
 	let hideTimer = null;
 	let lastId = null;
-	function err() {
-
-	}
+       function err(message = '오류가 발생했습니다') {
+               if (!toast) return;
+               clearTimeout(hideTimer);
+               msgEl.textContent = message;
+               undoBtn.style.display = 'none';
+               toast.classList.remove('hidden');
+               requestAnimationFrame(() => toast.classList.add('show'));
+               hideTimer = setTimeout(() => {
+                       hide();
+               }, 4000);
+       }
 
 	function hide() {
 		if (!toast) return;


### PR DESCRIPTION
## Summary
- implement `err()` in `save-toast.js` to show a brief error message

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b6838c1c4832781be57e26ee4dc40