### PR TITLE
Improve monthly drag

### DIFF
--- a/keep/src/main/resources/static/css/main/components/monthly.css
+++ b/keep/src/main/resources/static/css/main/components/monthly.css
@@ -82,7 +82,6 @@
 
 /* ghost element shown while dragging */
 .drag-ghost {
-  opacity: 0.5;
   pointer-events: none;
 }
 

--- a/keep/src/main/resources/static/js/main/components/monthly.js
+++ b/keep/src/main/resources/static/js/main/components/monthly.js
@@ -391,6 +391,7 @@
                 dragState = {
                         id,
                         startX: e.clientX,
+                        startY: e.clientY,
                         deltaDays: 0,
                         bars: allBars.map(el => ({
                                 el,
@@ -417,7 +418,10 @@
         function monthlyPointerMove(e) {
                 if (!dragState) return;
                 const cellWidth = monthlyState.calendar.querySelector('.day-cell').offsetWidth;
-                const delta = Math.round((e.clientX - dragState.startX) / cellWidth);
+                const cellHeight = monthlyState.calendar.querySelector('.day-cell').offsetHeight;
+                const deltaX = Math.round((e.clientX - dragState.startX) / cellWidth);
+                const deltaY = Math.round((e.clientY - dragState.startY) / cellHeight) * 7;
+                const delta = deltaX + deltaY;
                 if (delta === dragState.deltaDays) return;
                 dragState.deltaDays = delta;
                 dragState.bars.forEach(o => { o.el._dragging = true; });


### PR DESCRIPTION
## Summary
- remove opacity from drag ghost in monthly view
- allow dragging schedules in monthly view by week increments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b814f37548327baae86b1470dbb7b