### PR TITLE
Update header

### DIFF
--- a/keep/src/main/java/com/keep/member/controller/MemberApiController.java
+++ b/keep/src/main/java/com/keep/member/controller/MemberApiController.java
@@ -52,8 +52,10 @@ public class MemberApiController {
     // 3) 로그인 성공한 사용자 정보(Member 엔티티) 조회
 		Long memberId = memberService.findIdByEmail(memberDTO.getEmail());  
 
-    // 4) 세션에 MemberDTO 대신 Member 엔티티(또는 id)만 저장해도 OK
-    session.setAttribute("memberId", memberId); 
+    // 4) 세션에 사용자 정보 저장
+    session.setAttribute("memberId", memberId);
+    String hname = memberService.findHnameById(memberId);
+    session.setAttribute("hname", hname);
 
     UsernamePasswordAuthenticationToken authToken =
         new UsernamePasswordAuthenticationToken(

--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-	private final MemberRepository memberRepository;
-	private final PasswordEncoder passwordEncoder;
+        private final MemberRepository memberRepository;
+        private final PasswordEncoder passwordEncoder;
 
 	// 회원가입
 	@Transactional
@@ -46,7 +46,13 @@ public class MemberService {
 				.orElse(false);
 	}
 
-	public Long findIdByEmail(String email) {
-		return memberRepository.findIdByEmail(email);
-	}
+        public Long findIdByEmail(String email) {
+                return memberRepository.findIdByEmail(email);
+        }
+
+        public String findHnameById(Long id) {
+                return memberRepository.findById(id)
+                                .map(MemberEntity::getHname)
+                                .orElse(null);
+        }
 }

--- a/keep/src/main/resources/static/css/fragments/body.css
+++ b/keep/src/main/resources/static/css/fragments/body.css
@@ -108,6 +108,18 @@ header .head h1 {
   color: #555;
   margin-right: 15px;
 }
+.menu-icons a {
+  margin-right: 10px;
+  font-size: 1.2rem;
+  text-decoration: none;
+  color: #555;
+}
+.menu-icons a:last-child {
+  margin-right: 15px;
+}
+.menu-icons a:hover {
+  color: #000;
+}
 .logout button {
   background-color: #4f46e5;
   color: #ffffff;

--- a/keep/src/main/resources/templates/fragments/header.html
+++ b/keep/src/main/resources/templates/fragments/header.html
@@ -12,15 +12,19 @@
 
 	<div class="head">
 		<h1>일정</h1>
-		<div class="top-menu">
-			<div class="login-user">님 반갑습니다.</div>
-			<div class="logout">
-				<form action="/logout" method="post">
-					<button type="submit">
-						<span class="skip-info">로그아웃</span>
-					</button>
-				</form>
-			</div>
+                <div class="top-menu">
+                        <div class="login-user" th:text="${session.hname + '님 반갑습니다.'}">님 반갑습니다.</div>
+                        <div class="menu-icons">
+                                <a href="/friends" class="friend-icon" title="친구목록">👥</a>
+                                <a href="/dashboard" class="schedule-icon" title="일정">📅</a>
+                        </div>
+                        <div class="logout">
+                                <form action="/logout" method="post">
+                                        <button type="submit">
+                                                <span class="skip-info">로그아웃</span>
+                                        </button>
+                                </form>
+                        </div>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
## Summary
- show logged-in user name in header
- store user's display name in session on login
- add quick navigation links for friends and schedule
- style header icons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f58c198cc8327beb7c58be415dca8