### PR TITLE
Add notification modal in header

### DIFF
--- a/keep/src/main/resources/static/css/fragments/body.css
+++ b/keep/src/main/resources/static/css/fragments/body.css
@@ -120,6 +120,44 @@ header .head h1 {
 .menu-icons a:hover {
   color: #000;
 }
+.notification {
+  position: relative;
+  margin-right: 15px;
+}
+.notification-icon {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #555;
+}
+.notification-icon:hover {
+  color: #000;
+}
+.notification-modal {
+  position: absolute;
+  right: 0;
+  top: 28px;
+  width: 160px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  z-index: 150;
+}
+.notification-modal.hidden {
+  display: none;
+}
+.notification-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+}
 .logout button {
   background-color: #4f46e5;
   color: #ffffff;

--- a/keep/src/main/resources/static/js/notification-modal.js
+++ b/keep/src/main/resources/static/js/notification-modal.js
@@ -1,0 +1,22 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('notification-btn');
+  const modal = document.getElementById('notification-modal');
+  const close = document.getElementById('notification-close');
+  if (!btn || !modal || !close) return;
+
+  const hide = () => modal.classList.add('hidden');
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    modal.classList.toggle('hidden');
+  });
+
+  close.addEventListener('click', hide);
+
+  document.addEventListener('click', (e) => {
+    if (!modal.classList.contains('hidden') && !modal.contains(e.target) && e.target !== btn) {
+      hide();
+    }
+  });
+});

--- a/keep/src/main/resources/templates/fragments/body.html
+++ b/keep/src/main/resources/templates/fragments/body.html
@@ -17,10 +17,11 @@
 	<footer class="main-footer">&copy; <span>2025</span> 포트폴리오	</footer>
 
 
-	<script type="text/javascript">
-		document.addEventListener('DOMContentLoaded', function() {
-		});
-	</script>
-	<th:block layout:fragment="script"></th:block>
+        <script type="text/javascript">
+                document.addEventListener('DOMContentLoaded', function() {
+                });
+        </script>
+        <script th:src="@{/js/notification-modal.js}"></script>
+        <th:block layout:fragment="script"></th:block>
 </body>
 </html>

--- a/keep/src/main/resources/templates/fragments/header.html
+++ b/keep/src/main/resources/templates/fragments/header.html
@@ -18,6 +18,13 @@
                                 <a href="/friends" class="friend-icon" title="친구목록">👥</a>
                                 <a href="/dashboard" class="schedule-icon" title="일정">📅</a>
                         </div>
+                        <div class="notification">
+                                <button type="button" id="notification-btn" class="notification-icon" title="알림">🔔</button>
+                                <div id="notification-modal" class="notification-modal hidden">
+                                        <button type="button" id="notification-close" class="notification-close">&times;</button>
+                                        <p>알림이 없습니다.</p>
+                                </div>
+                        </div>
                         <div class="logout">
                                 <form action="/logout" method="post">
                                         <button type="submit">


### PR DESCRIPTION
## Summary
- add notification icon next to logout in header
- show small popup with a close button and message when clicked
- style notification modal and icon
- load script globally to manage opening and closing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f5de68ab88327937352a2140d9868