### PR TITLE
Implement share page skeleton

### DIFF
--- a/keep/src/main/resources/static/css/main/share.css
+++ b/keep/src/main/resources/static/css/main/share.css
@@ -1,0 +1,83 @@
+.search-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.search-bar input[type="text"] {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.search-bar button {
+  padding: 6px 10px;
+  border: none;
+  background-color: #4f46e5;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.list-toggle {
+  margin-bottom: 10px;
+}
+.list-toggle .toggle-btn {
+  padding: 6px 12px;
+  border: none;
+  background-color: #eef2ff;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-right: 4px;
+}
+.list-toggle .toggle-btn.active {
+  background-color: #4f46e5;
+  color: #fff;
+}
+.list-container {
+  background: #fff;
+  border-radius: 8px;
+  padding: 10px;
+  border: 1px solid #e5e7eb;
+}
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}
+.list-item:last-child {
+  border-bottom: none;
+}
+.list-item button {
+  padding: 4px 8px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.accept-btn {
+  background-color: #4f46e5;
+  color: #fff;
+  margin-right: 4px;
+}
+.reject-btn {
+  background-color: #e5e7eb;
+}
+.invite-btn {
+  background-color: #4f46e5;
+  color: #fff;
+}
+.request-btn {
+  padding: 8px 16px;
+  border: none;
+  background-color: #4f46e5;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.request-message {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 10px;
+}

--- a/keep/src/main/resources/static/js/main/share.js
+++ b/keep/src/main/resources/static/js/main/share.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const fragmentContainer = document.getElementById('fragment-container');
+    const viewBtns = document.querySelectorAll('.view-btn');
+
+    function loadView(view) {
+        fragmentContainer.style.opacity = 0;
+        fetch(`/share/fragment/${view}`)
+            .then(res => {
+                if (!res.ok) throw new Error('network');
+                return res.text();
+            })
+            .then(html => {
+                fragmentContainer.innerHTML = html;
+                requestAnimationFrame(() => {
+                    fragmentContainer.style.opacity = 1;
+                });
+            })
+            .catch(err => console.error(err));
+    }
+
+    viewBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const view = btn.dataset.view;
+            viewBtns.forEach(b => b.classList.toggle('active', b === btn));
+            loadView(view);
+        });
+    });
+
+    loadView('request');
+});

--- a/keep/src/main/resources/templates/main/share/components/share-invite.html
+++ b/keep/src/main/resources/templates/main/share/components/share-invite.html
@@ -1,7 +1,16 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
+    <div class="search-bar">
+        <input type="text" placeholder="이름 검색" />
+        <button type="button">검색</button>
+    </div>
+    <div class="list-container">
+        <div class="list-item">
+            <span>사용자 이름</span>
+            <button class="invite-btn" type="button">초대하기</button>
+        </div>
+    </div>
 </div>
 </html>
-

--- a/keep/src/main/resources/templates/main/share/components/share-list.html
+++ b/keep/src/main/resources/templates/main/share/components/share-list.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
+    <div class="list-toggle">
+        <button class="toggle-btn active" data-target="shared">공유한 인원</button>
+        <button class="toggle-btn" data-target="received">공유받은 인원</button>
+    </div>
+    <div class="list-container" id="share-list">
+        <div class="list-item"><span>사용자 이름</span></div>
+    </div>
 </div>
 </html>
-

--- a/keep/src/main/resources/templates/main/share/components/share-manage.html
+++ b/keep/src/main/resources/templates/main/share/components/share-manage.html
@@ -1,7 +1,19 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
+    <div class="list-toggle">
+        <button class="toggle-btn active" data-target="request">받은 요청</button>
+        <button class="toggle-btn" data-target="invite">받은 초대</button>
+    </div>
+    <div class="list-container">
+        <div class="list-item">
+            <span>사용자 이름</span>
+            <div>
+                <button class="accept-btn" type="button">수락</button>
+                <button class="reject-btn" type="button">거절</button>
+            </div>
+        </div>
+    </div>
 </div>
 </html>
-

--- a/keep/src/main/resources/templates/main/share/components/share-request.html
+++ b/keep/src/main/resources/templates/main/share/components/share-request.html
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
+    <div class="search-bar">
+        <input type="text" placeholder="이름 검색" />
+        <button type="button">검색</button>
+    </div>
+    <textarea class="request-message" rows="3" placeholder="메시지를 입력하세요"></textarea>
+    <button type="button" class="request-btn">요청하기</button>
 </div>
 </html>
-

--- a/keep/src/main/resources/templates/main/share/share-main.html
+++ b/keep/src/main/resources/templates/main/share/share-main.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"	xmlns:th="http://www.thymeleaf.org"	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"	layout:decorate="layouts/layout">
+<html xmlns="http://www.w3.org/1999/xhtml"      xmlns:th="http://www.thymeleaf.org"     xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"        layout:decorate="layouts/layout">
 <!--/* title */-->
 <th:block layout:fragment="title">
-	<title>리스트</title>
+        <title>공유</title>
 </th:block>
 
 <!--/* style */-->
 <th:block layout:fragment="add-css">
-<!-- dash.html head -->
+        <link rel="stylesheet" th:href="@{/css/main/dashboard.css}" />
+        <link rel="stylesheet" th:href="@{/css/main/share.css}" />
 </th:block>
 <!--/* content */-->
 <th:block layout:fragment="content">
-	<div class="dashboard-header">
-		<!-- 좌측: 비워둔 영역 (추후 아이콘 등 추가 가능) -->
-		<div class="header-left"></div>
-		<!-- 우측: 뷰 토글 버튼 -->
-		<div class="dashboard-header-right">
-			<button class="view-btn" data-view="today">목록</button>
-			<button class="view-btn" data-view="daily">초대</button>
-			<button class="view-btn active" data-view="weekly">요청</button>
-			<button class="view-btn" data-view="monthly">관리</button>
-		</div>
-	</div>
-	<div id="fragment-container"></div>
-	<!-- 	daily.html 등록 모달 -->	
+        <div class="dashboard-header">
+                <!-- 좌측: 비워둔 영역 (추후 아이콘 등 추가 가능) -->
+                <div class="header-left"></div>
+                <!-- 우측: 뷰 토글 버튼 -->
+                <div class="dashboard-header-right">
+                        <button class="view-btn" data-view="list">목록</button>
+                        <button class="view-btn active" data-view="request">요청</button>
+                        <button class="view-btn" data-view="invite">초대</button>
+                        <button class="view-btn" data-view="manage">관리</button>
+                </div>
+        </div>
+        <div id="fragment-container"></div>
+        <!--    toast -->
              <div th:replace="~{main/dashboard/components/modal/save-toast :: save-toast}"></div>
 
 </th:block>
 <!--/* script */-->
 <th:block layout:fragment="script">
+        <script th:src="@{/js/main/share.js}"></script>
         <script th:src="@{/js/main/components/save-toast.js}"></script>
 </th:block>
 
 </html>
-  


### PR DESCRIPTION
## Summary
- build share-main.html with header and four view buttons
- implement fragments for list, request, invite and manage
- add share.js for fragment loading
- style share components with share.css

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f6edde628832794e760fd60ac49f6