### PR TITLE
Implement share main layout like dashboard

### DIFF
--- a/keep/src/main/resources/static/css/main/share/share.css
+++ b/keep/src/main/resources/static/css/main/share/share.css
@@ -1,3 +1,56 @@
+.share-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  border-radius: 10px 10px 0 0;
+  position: sticky;
+  top: 0;
+  z-index: 40;
+}
+
+.share-header .header-left {
+  flex: 1;
+}
+
+.share-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.share-header-center {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.view-btn {
+  padding: 6px 10px;
+  border: none;
+  background-color: #eef2ff;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.view-btn:hover {
+  background-color: #d0d7ff;
+}
+
+.view-btn.active {
+  background-color: #4f46e5;
+  color: #fff;
+}
+
+#fragment-container {
+  margin-top: 20px;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
 .search-bar {
   display: flex;
   gap: 8px;

--- a/keep/src/main/resources/templates/main/share/share-main.html
+++ b/keep/src/main/resources/templates/main/share/share-main.html
@@ -18,6 +18,8 @@
         <div class="share-header">
                 <!-- 좌측: 비워둔 영역 (추후 아이콘 등 추가 가능) -->
                 <div class="header-left"></div>
+                <!-- 중앙: 비워둔 영역 (필요 시 내용 추가) -->
+                <div class="share-header-center"></div>
                 <!-- 우측: 뷰 토글 버튼 -->
                 <div class="share-header-right">
                         <button class="view-btn" data-view="list">목록</button>


### PR DESCRIPTION
## Summary
- align `share-main.html` structure with dashboard header sections
- style `share-main` with header and toggle buttons for a consistent look

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f7c6702d483279e2d139beabf51a3