### PR TITLE
Implement schedule share invite

### DIFF
--- a/keep/src/main/java/com/keep/member/repository/MemberRepository.java
+++ b/keep/src/main/java/com/keep/member/repository/MemberRepository.java
@@ -16,4 +16,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
   
   @Query("select m.id from MemberEntity m where m.email = :email")
   Long findIdByEmail(@Param("email") String email);
+
+  // 이름 검색 (대소문자 구분 없음)
+  @Query("select m from MemberEntity m where lower(m.hname) like lower(concat('%', :name, '%'))")
+  java.util.List<MemberEntity> searchByHname(@Param("name") String name);
 }

--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -55,4 +55,10 @@ public class MemberService {
                                 .map(MemberEntity::getHname)
                                 .orElse(null);
         }
+
+        public java.util.List<MemberDTO> searchByName(String name) {
+                return memberRepository.searchByHname(name).stream()
+                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null))
+                                .toList();
+        }
 }

--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -1,0 +1,39 @@
+package com.keep.share.controller;
+
+import com.keep.member.dto.MemberDTO;
+import com.keep.member.service.MemberService;
+import com.keep.share.service.ScheduleShareService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/schedules/{scheduleId}/share")
+@RequiredArgsConstructor
+public class ScheduleShareApiController {
+    private final MemberService memberService;
+    private final ScheduleShareService shareService;
+
+    @GetMapping("/search")
+    public List<MemberDTO> search(@PathVariable Long scheduleId, @RequestParam("name") String name) {
+        List<MemberDTO> members = memberService.searchByName(name);
+        List<Long> invitedIds = shareService.findInviteeIds(scheduleId);
+        return members.stream()
+                .filter(m -> !invitedIds.contains(m.getId()))
+                .toList();
+    }
+
+    @PostMapping("/invite")
+    public ResponseEntity<?> invite(Authentication authentication,
+                                    @PathVariable Long scheduleId,
+                                    @RequestBody Map<String, Long> body) {
+        Long inviteeId = body.get("inviteeId");
+        Long inviterId = Long.valueOf(authentication.getName());
+        shareService.invite(scheduleId, inviterId, inviteeId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
+++ b/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
@@ -1,0 +1,27 @@
+package com.keep.share.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "SCHEDULE_SHARE")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleShareEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "schedule_share_seq_gen")
+    @SequenceGenerator(name = "schedule_share_seq_gen", sequenceName = "SCHEDULE_SHARE_SEQ", allocationSize = 1)
+    @Column(name = "SCHEDULE_SHARE_ID")
+    private Long id;
+
+    @Column(name = "SCHEDULES_ID", nullable = false)
+    private Long scheduleId;
+
+    @Column(name = "INVITER_ID", nullable = false)
+    private Long inviterId;
+
+    @Column(name = "INVITEE_ID", nullable = false)
+    private Long inviteeId;
+}

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -1,0 +1,10 @@
+package com.keep.share.repository;
+
+import com.keep.share.entity.ScheduleShareEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEntity, Long> {
+    List<ScheduleShareEntity> findByScheduleId(Long scheduleId);
+    boolean existsByScheduleIdAndInviteeId(Long scheduleId, Long inviteeId);
+}

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -1,0 +1,32 @@
+package com.keep.share.service;
+
+import com.keep.share.entity.ScheduleShareEntity;
+import com.keep.share.repository.ScheduleShareRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleShareService {
+    private final ScheduleShareRepository repository;
+
+    public List<Long> findInviteeIds(Long scheduleId) {
+        return repository.findByScheduleId(scheduleId).stream()
+                .map(ScheduleShareEntity::getInviteeId)
+                .collect(Collectors.toList());
+    }
+
+    public void invite(Long scheduleId, Long inviterId, Long inviteeId) {
+        if (!repository.existsByScheduleIdAndInviteeId(scheduleId, inviteeId)) {
+            ScheduleShareEntity entity = ScheduleShareEntity.builder()
+                    .scheduleId(scheduleId)
+                    .inviterId(inviterId)
+                    .inviteeId(inviteeId)
+                    .build();
+            repository.save(entity);
+        }
+    }
+}

--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -1,0 +1,25 @@
+.list-container {
+  margin-top: 20px;
+}
+
+.placeholder {
+  padding: 40px;
+  text-align: center;
+  color: #888;
+}
+
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.invite-btn {
+  background-color: #4CAF50;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -1,1 +1,46 @@
-// JS for share invite view
+document.addEventListener('DOMContentLoaded', () => {
+    const list = document.getElementById('invite-list');
+    const input = document.getElementById('invite-search-input');
+    const btn = document.getElementById('invite-search-btn');
+    const scheduleId = document.getElementById('fragment-container').dataset.scheduleId;
+
+    function renderEmpty(msg) {
+        list.innerHTML = `<div class="placeholder">${msg}</div>`;
+    }
+
+    btn?.addEventListener('click', () => {
+        const name = input.value.trim();
+        if (!name) return;
+        fetch(`/api/schedules/${scheduleId}/share/search?name=` + encodeURIComponent(name))
+            .then(res => res.json())
+            .then(data => {
+                if (data.length === 0) {
+                    renderEmpty('검색 결과가 없습니다.');
+                    return;
+                }
+                list.innerHTML = '';
+                data.forEach(m => {
+                    const div = document.createElement('div');
+                    div.className = 'list-item';
+                    div.innerHTML = `<span>${m.hname}</span><button class="invite-btn" data-id="${m.id}">초대하기</button>`;
+                    list.appendChild(div);
+                });
+            });
+    });
+
+    list?.addEventListener('click', e => {
+        if (e.target.classList.contains('invite-btn')) {
+            const id = e.target.dataset.id;
+            fetch(`/api/schedules/${scheduleId}/share/invite`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({inviteeId: id})
+            }).then(res => {
+                if (res.ok) {
+                    e.target.textContent = '초대 완료';
+                    e.target.disabled = true;
+                }
+            });
+        }
+    });
+});

--- a/keep/src/main/resources/templates/main/share/components/share-invite.html
+++ b/keep/src/main/resources/templates/main/share/components/share-invite.html
@@ -3,10 +3,11 @@
       xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
     <div class="search-bar">
-        <input type="text" placeholder="이름 검색" />
-        <button type="button">검색</button>
+        <input type="text" id="invite-search-input" placeholder="이름 검색" />
+        <button type="button" id="invite-search-btn">검색</button>
     </div>
-    <div class="list-container">
+    <div class="list-container" id="invite-list">
+        <div class="placeholder">초대할 사람을 검색하세요.</div>
     </div>
 </div>
 </html>

--- a/keep/src/main/resources/templates/main/share/share-main.html
+++ b/keep/src/main/resources/templates/main/share/share-main.html
@@ -28,7 +28,7 @@
                         <button class="view-btn" data-view="manage">관리</button>
                 </div>
         </div>
-        <div id="fragment-container"></div>
+        <div id="fragment-container" th:data-schedule-id="${param.scheduleId}"></div>
 
 </th:block>
 <!--/* script */-->


### PR DESCRIPTION
## Summary
- add repository query for name search
- add service method to search names
- create schedule share entity/service/controller
- decorate invite fragment and add JS logic for searching and inviting
- expose scheduleId on share main page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e45e46083278dd9dd0dc6cc3e26