### PR TITLE
Update schedule share schema and logic

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -2,6 +2,7 @@ package com.keep.share.controller;
 
 import com.keep.member.dto.MemberDTO;
 import com.keep.member.service.MemberService;
+import com.keep.share.dto.ScheduleShareDTO;
 import com.keep.share.service.ScheduleShareService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,7 +10,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/schedules/{scheduleId}/share")
@@ -21,7 +21,7 @@ public class ScheduleShareApiController {
     @GetMapping("/search")
     public List<MemberDTO> search(@PathVariable Long scheduleId, @RequestParam("name") String name) {
         List<MemberDTO> members = memberService.searchByName(name);
-        List<Long> invitedIds = shareService.findInviteeIds(scheduleId);
+        List<Long> invitedIds = shareService.findReceiverIds(scheduleId);
         return members.stream()
                 .filter(m -> !invitedIds.contains(m.getId()))
                 .toList();
@@ -30,10 +30,10 @@ public class ScheduleShareApiController {
     @PostMapping("/invite")
     public ResponseEntity<?> invite(Authentication authentication,
                                     @PathVariable Long scheduleId,
-                                    @RequestBody Map<String, Long> body) {
-        Long inviteeId = body.get("inviteeId");
-        Long inviterId = Long.valueOf(authentication.getName());
-        shareService.invite(scheduleId, inviterId, inviteeId);
+                                    @RequestBody ScheduleShareDTO dto) {
+        Long receiverId = dto.getReceiverId();
+        Long sharerId = Long.valueOf(authentication.getName());
+        shareService.invite(scheduleId, sharerId, receiverId);
         return ResponseEntity.ok().build();
     }
 }

--- a/keep/src/main/java/com/keep/share/dto/ScheduleShareDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/ScheduleShareDTO.java
@@ -1,0 +1,19 @@
+package com.keep.share.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleShareDTO {
+    private Long scheduleShareId;
+    private Long scheduleId;
+    private Long sharerId;
+    private Long receiverId;
+    private String canEdit;
+    private String acceptYn;
+}

--- a/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
+++ b/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
@@ -19,9 +19,42 @@ public class ScheduleShareEntity {
     @Column(name = "SCHEDULES_ID", nullable = false)
     private Long scheduleId;
 
-    @Column(name = "INVITER_ID", nullable = false)
-    private Long inviterId;
+    @Column(name = "SHARER_ID", nullable = false)
+    private Long sharerId;
 
-    @Column(name = "INVITEE_ID", nullable = false)
-    private Long inviteeId;
+    @Column(name = "RECEIVER_ID", nullable = false)
+    private Long receiverId;
+
+    @Column(name = "CAN_EDIT")
+    private String canEdit;
+
+    @Column(name = "ACCEPT_YN")
+    private String acceptYn;
+
+    @Column(name = "CREATED_BY")
+    private Long createdBy;
+
+    @Column(name = "CREATION_DATE")
+    private java.time.LocalDateTime creationDate;
+
+    @Column(name = "LAST_UPDATED_BY")
+    private Long lastUpdatedBy;
+
+    @Column(name = "LAST_UPDATE_DATE")
+    private java.time.LocalDateTime lastUpdateDate;
+
+    @Column(name = "LAST_UPDATE_LOGIN")
+    private Long lastUpdateLogin;
+
+    @PrePersist
+    protected void onCreate() {
+        java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        this.creationDate = now;
+        this.lastUpdateDate = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.lastUpdateDate = java.time.LocalDateTime.now();
+    }
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEntity, Long> {
     List<ScheduleShareEntity> findByScheduleId(Long scheduleId);
-    boolean existsByScheduleIdAndInviteeId(Long scheduleId, Long inviteeId);
+    boolean existsByScheduleIdAndReceiverId(Long scheduleId, Long receiverId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -13,18 +13,23 @@ import java.util.stream.Collectors;
 public class ScheduleShareService {
     private final ScheduleShareRepository repository;
 
-    public List<Long> findInviteeIds(Long scheduleId) {
+    public List<Long> findReceiverIds(Long scheduleId) {
         return repository.findByScheduleId(scheduleId).stream()
-                .map(ScheduleShareEntity::getInviteeId)
+                .map(ScheduleShareEntity::getReceiverId)
                 .collect(Collectors.toList());
     }
 
-    public void invite(Long scheduleId, Long inviterId, Long inviteeId) {
-        if (!repository.existsByScheduleIdAndInviteeId(scheduleId, inviteeId)) {
+    public void invite(Long scheduleId, Long sharerId, Long receiverId) {
+        if (!repository.existsByScheduleIdAndReceiverId(scheduleId, receiverId)) {
             ScheduleShareEntity entity = ScheduleShareEntity.builder()
                     .scheduleId(scheduleId)
-                    .inviterId(inviterId)
-                    .inviteeId(inviteeId)
+                    .sharerId(sharerId)
+                    .receiverId(receiverId)
+                    .canEdit("N")
+                    .acceptYn("N")
+                    .createdBy(sharerId)
+                    .lastUpdatedBy(sharerId)
+                    .lastUpdateLogin(sharerId)
                     .build();
             repository.save(entity);
         }

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
             fetch(`/api/schedules/${scheduleId}/share/invite`, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({inviteeId: id})
+                body: JSON.stringify({receiverId: id})
             }).then(res => {
                 if (res.ok) {
                     e.target.textContent = '초대 완료';


### PR DESCRIPTION
## Summary
- support new schedule share schema
- add DTO for schedule share
- update controller/service/repo to new column names
- adjust invite JS client to send `receiverId`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f820e31f883279767ca84470b8c80