### PR TITLE
Improve schedule share search

### DIFF
--- a/keep/src/main/java/com/keep/member/repository/MemberRepository.java
+++ b/keep/src/main/java/com/keep/member/repository/MemberRepository.java
@@ -20,4 +20,16 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
   // 이름 검색 (대소문자 구분 없음)
   @Query("select m from MemberEntity m where lower(m.hname) like lower(concat('%', :name, '%'))")
   java.util.List<MemberEntity> searchByHname(@Param("name") String name);
+
+  @Query("""
+      select m from MemberEntity m
+      where lower(m.hname) like lower(concat('%', :name, '%'))
+        and not exists (
+            select 1 from ScheduleShareEntity s
+            where s.scheduleId = :scheduleId
+              and s.receiverId = m.id
+        )
+      """)
+  java.util.List<MemberEntity> searchAvailableForShare(@Param("scheduleId") Long scheduleId,
+                                                      @Param("name") String name);
 }

--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -61,4 +61,10 @@ public class MemberService {
                                 .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null))
                                 .toList();
         }
+
+        public java.util.List<MemberDTO> searchAvailableForShare(Long scheduleId, String name) {
+                return memberRepository.searchAvailableForShare(scheduleId, name).stream()
+                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null))
+                                .toList();
+        }
 }

--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -20,11 +20,7 @@ public class ScheduleShareApiController {
 
     @GetMapping("/search")
     public List<MemberDTO> search(@PathVariable Long scheduleId, @RequestParam("name") String name) {
-        List<MemberDTO> members = memberService.searchByName(name);
-        List<Long> invitedIds = shareService.findReceiverIds(scheduleId);
-        return members.stream()
-                .filter(m -> !invitedIds.contains(m.getId()))
-                .toList();
+        return memberService.searchAvailableForShare(scheduleId, name);
     }
 
     @PostMapping("/invite")


### PR DESCRIPTION
## Summary
- add `searchAvailableForShare` query in `MemberRepository`
- expose new method in `MemberService`
- simplify `ScheduleShareApiController` search endpoint

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684f9b85f2388327a38d936c0724ba88