### PR TITLE
Filter current user in schedule share search

### DIFF
--- a/keep/src/main/java/com/keep/member/repository/MemberRepository.java
+++ b/keep/src/main/java/com/keep/member/repository/MemberRepository.java
@@ -24,6 +24,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
   @Query("""
       select m from MemberEntity m
       where lower(m.hname) like lower(concat('%', :name, '%'))
+        and m.id <> :excludeId
         and not exists (
             select 1 from ScheduleShareEntity s
             where s.scheduleId = :scheduleId
@@ -31,5 +32,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
         )
       """)
   java.util.List<MemberEntity> searchAvailableForShare(@Param("scheduleId") Long scheduleId,
+                                                      @Param("excludeId") Long excludeId,
                                                       @Param("name") String name);
 }

--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -62,8 +62,8 @@ public class MemberService {
                                 .toList();
         }
 
-        public java.util.List<MemberDTO> searchAvailableForShare(Long scheduleId, String name) {
-                return memberRepository.searchAvailableForShare(scheduleId, name).stream()
+        public java.util.List<MemberDTO> searchAvailableForShare(Long scheduleId, Long excludeId, String name) {
+                return memberRepository.searchAvailableForShare(scheduleId, excludeId, name).stream()
                                 .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null))
                                 .toList();
         }

--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -19,8 +19,11 @@ public class ScheduleShareApiController {
     private final ScheduleShareService shareService;
 
     @GetMapping("/search")
-    public List<MemberDTO> search(@PathVariable Long scheduleId, @RequestParam("name") String name) {
-        return memberService.searchAvailableForShare(scheduleId, name);
+    public List<MemberDTO> search(Authentication authentication,
+                                  @PathVariable Long scheduleId,
+                                  @RequestParam("name") String name) {
+        Long sharerId = Long.valueOf(authentication.getName());
+        return memberService.searchAvailableForShare(scheduleId, sharerId, name);
     }
 
     @PostMapping("/invite")


### PR DESCRIPTION
## Summary
- adjust search query to exclude requesting user
- update service and controller to use session user ID

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f9e7f349c8327b74f813a7426388c