### PR TITLE
Implement ScheduleShare manage APIs

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -29,14 +29,32 @@ public class ScheduleShareApiController {
                 return members;
         }
 
-	@GetMapping(path = "/invite")
-	public List<MemberDTO> search(@RequestParam("name") String name, Authentication authentication) {
-		Long sharerId = Long.valueOf(authentication.getName());
-		return memberService.searchAvailableForShare(sharerId, name);
-	}
-	@PostMapping("/invite")
-	public ResponseEntity<?> invite(Authentication authentication,@RequestBody ScheduleShareDTO scheduleShareDTO	) {
-		shareService.invite(Long.parseLong(authentication.getName()), scheduleShareDTO.getReceiverId());
-		return ResponseEntity.ok().build();
-	}
+        @GetMapping(path = "/invite")
+        public List<MemberDTO> search(@RequestParam("name") String name, Authentication authentication) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                return memberService.searchAvailableForShare(sharerId, name);
+        }
+        @PostMapping("/invite")
+        public ResponseEntity<?> invite(Authentication authentication,@RequestBody ScheduleShareDTO scheduleShareDTO    ) {
+                shareService.invite(Long.parseLong(authentication.getName()), scheduleShareDTO.getReceiverId());
+                return ResponseEntity.ok().build();
+        }
+
+        @GetMapping("/manage/request")
+        public List<MemberDTO> loadRequests(Authentication authentication) {
+                Long sharerId = Long.parseLong(authentication.getName());
+                return shareService.findRequests(sharerId).stream()
+                        .map(e -> new MemberDTO(e.getReceiverId(), null, null,
+                                memberService.findHnameById(e.getReceiverId()), null, false))
+                        .toList();
+        }
+
+        @GetMapping("/manage/invite")
+        public List<MemberDTO> loadInvites(Authentication authentication) {
+                Long receiverId = Long.parseLong(authentication.getName());
+                return shareService.findInvites(receiverId).stream()
+                        .map(e -> new MemberDTO(e.getSharerId(), null, null,
+                                memberService.findHnameById(e.getSharerId()), null, false))
+                        .toList();
+        }
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEntity, Long> {
     List<ScheduleShareEntity> findBySharerId(Long sharerId);
+    List<ScheduleShareEntity> findBySharerIdAndAcceptYn(Long sharerId, String acceptYn);
+    List<ScheduleShareEntity> findByReceiverIdAndAcceptYn(Long receiverId, String acceptYn);
     boolean existsBySharerIdAndReceiverId(Long sharerId, Long receiverId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -34,4 +34,11 @@ public class ScheduleShareService {
         }
     }
 
+    public List<ScheduleShareEntity> findRequests(Long sharerId) {
+        return repository.findBySharerIdAndAcceptYn(sharerId, "N");
+    }
+
+    public List<ScheduleShareEntity> findInvites(Long receiverId) {
+        return repository.findByReceiverIdAndAcceptYn(receiverId, "N");
+    }
 }


### PR DESCRIPTION
## Summary
- add repository methods for pending requests/invites
- expose service methods for pending requests and invites
- add API endpoints to load share manage lists

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684fc163d8e083278df94817a1aa120a