### PR TITLE
Fix placeholder heights to fit screen

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -3,7 +3,8 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  min-height: 70vh;
+  /* Ensure the footer is visible without scrolling */
+  min-height: calc(100vh - 220px);
 }
 
 .placeholder {
@@ -12,7 +13,8 @@
   color: #888;
   width: 100%;
   font-size: 1.6rem;
-  min-height: 60vh;
+  /* Match container height to occupy remaining space */
+  min-height: calc(100vh - 220px);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/keep/src/main/resources/static/css/main/share/components/share-request.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-request.css
@@ -1,6 +1,7 @@
 #request-list {
   margin: 10px 0;
-  min-height: 70vh;
+  /* Adjust height so the footer remains visible without scroll */
+  min-height: calc(100vh - 220px);
 }
 
 .placeholder {
@@ -9,7 +10,8 @@
   color: #888;
   width: 100%;
   font-size: 1.6rem;
-  min-height: 60vh;
+  /* Fill remaining space considering header and footer */
+  min-height: calc(100vh - 220px);
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- keep footer visible without scroll on share pages
- set placeholder and list container heights based on viewport

## Testing
- `./keep/gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684fcbf1acd883278310e799ceff3e73