### PR TITLE
Sync share invite UI with request view

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -1,10 +1,7 @@
-.list-container {
-  margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
+#invite-list {
+  margin: 10px 0;
   /* Ensure the footer is visible without scrolling */
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 240px);
 }
 
 .placeholder {
@@ -14,7 +11,7 @@
   width: 100%;
   font-size: 1.6rem;
   /* Match container height to occupy remaining space */
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 240px);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/keep/src/main/resources/static/css/main/share/components/share-request.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-request.css
@@ -1,7 +1,7 @@
 #request-list {
   margin: 10px 0;
   /* Adjust height so the footer remains visible without scroll */
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 240px);
 }
 
 .placeholder {
@@ -11,7 +11,7 @@
   width: 100%;
   font-size: 1.6rem;
   /* Fill remaining space considering header and footer */
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 240px);
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- unify share invite placeholder styles with request styles
- resize share invite and request areas so the footer stays visible

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684fcde0b7c8832792759ad0ec238c37