### PR TITLE
Add toast and reset logic for share requests

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-request.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-request.css
@@ -29,3 +29,21 @@
   background-color: #666;
   cursor: not-allowed;
 }
+
+.request-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  background: #323232;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 200;
+}
+
+.request-toast.show {
+  opacity: 1;
+}

--- a/keep/src/main/resources/static/js/main/share/components/share-request.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-request.js
@@ -88,6 +88,18 @@
                 });
         });
 
+        function showToast(message, duration = 3000) {
+            const toast = document.createElement('div');
+            toast.className = 'request-toast';
+            toast.textContent = message;
+            document.body.appendChild(toast);
+            requestAnimationFrame(() => toast.classList.add('show'));
+            setTimeout(() => {
+                toast.classList.remove('show');
+                toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+            }, duration);
+        }
+
         requestBtn?.addEventListener('click', () => {
             if (!selectedId) return;
             fetch('/api/share/request', {
@@ -96,8 +108,11 @@
                 body: JSON.stringify({ sharerId: selectedId, message: messageEl.value })
             }).then(res => {
                 if (res.ok) {
-                    requestBtn.textContent = '요청 완료';
-                    requestBtn.disabled = true;
+                    showToast('요청이 완료되었습니다.');
+                    input.value = '';
+                    selectedId = null;
+                    hideControls();
+                    renderEmpty('요청할 사람을 선택해 주세요.');
                 }
             });
         });


### PR DESCRIPTION
## Summary
- reset share request view on completion
- display bottom toast confirming request

## Testing
- `./keep/gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850c0e22ca483279d0f2fdf3783828e