### PR TITLE
Add invite completion toast

### DIFF
--- a/keep/src/main/resources/static/js/main/common/toast.js
+++ b/keep/src/main/resources/static/js/main/common/toast.js
@@ -4,17 +4,21 @@
 	const undoBtn = document.getElementById('save-toast-undo');
 	let hideTimer = null;
 	let lastId = null;
-       function err(message = '오류가 발생했습니다') {
-               if (!toast) return;
-               clearTimeout(hideTimer);
-               msgEl.textContent = message;
-               undoBtn.style.display = 'none';
-               toast.classList.remove('hidden');
-               requestAnimationFrame(() => toast.classList.add('show'));
-               hideTimer = setTimeout(() => {
-                       hide();
-               }, 4000);
-       }
+      function err(message = '오류가 발생했습니다') {
+              if (!toast) return;
+              clearTimeout(hideTimer);
+              msgEl.textContent = message;
+              undoBtn.style.display = 'none';
+              toast.classList.remove('hidden');
+              requestAnimationFrame(() => toast.classList.add('show'));
+              hideTimer = setTimeout(() => {
+                      hide();
+              }, 4000);
+      }
+
+      function showMessage(message) {
+              err(message);
+      }
 
 	function hide() {
 		if (!toast) return;
@@ -48,9 +52,10 @@
 		}, 4000);
 	}
 
-	window.saveToast = {
-		showSaving,
-		showSaved,
-		hide
-	};
+        window.saveToast = {
+                showSaving,
+                showSaved,
+                showMessage,
+                hide
+        };
 })();

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -40,15 +40,18 @@
 									method: 'POST',
 									headers: { 'Content-Type': 'application/json' },
 									body: JSON.stringify({ receiverId: m.id })
-								}).then(res => {
-									if (res.ok) {
-										button.textContent = '초대 완료';
-										button.disabled = true;
-										button.classList.add('disabled');
-									}
-								});
-							});
-						}
+                                                                }).then(res => {
+                                                                        if (res.ok) {
+                                                                               button.textContent = '초대 완료';
+                                                                               button.disabled = true;
+                                                                               button.classList.add('disabled');
+                                                                               if (window.saveToast && window.saveToast.showMessage) {
+                                                                                       window.saveToast.showMessage('초대가 완료되었습니다');
+                                                                               }
+                                                                        }
+                                                                });
+                                                        });
+                                                }
 						div.appendChild(document.createElement('span')).textContent = m.hname;
 						div.appendChild(button);
 						list.appendChild(div);

--- a/keep/src/main/resources/templates/main/share/share-main.html
+++ b/keep/src/main/resources/templates/main/share/share-main.html
@@ -12,6 +12,8 @@
         <link id="share-list-css"rel="stylesheet" th:href="@{/css/main/share/components/share-list.css}" />
         <link id="share-manage-css"rel="stylesheet" th:href="@{/css/main/share/components/share-manage.css}" />
         <link id="share-request-css"rel="stylesheet" th:href="@{/css/main/share/components/share-request.css}" />
+        <!-- Toast style reuse -->
+        <link rel="stylesheet" th:href="@{/css/main/dashboard/modal/save-toast.css}" />
 </th:block>
 <!--/* content */-->
 <th:block layout:fragment="content">
@@ -29,6 +31,7 @@
                 </div>
         </div>
         <div id="fragment-container" data-id ="${session.memberId}"></div>
+        <div th:replace="~{common/toast :: save-toast}"></div>
 
 </th:block>
 <!--/* script */-->
@@ -38,6 +41,7 @@
         <script th:src="@{/js/main/share/components/share-list.js}"></script>
         <script th:src="@{/js/main/share/components/share-request.js}"></script>
         <script th:src="@{/js/main/share/components/share-manage.js}"></script>
+        <script th:src="@{/js/main/common/toast.js}"></script>
 </th:block>
 
 </html>


### PR DESCRIPTION
## Summary
- include toast widget on share page and load toast script
- export `showMessage` helper in toast.js
- display completion toast after sending invite

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6850c107bf348327b3545b8aeab016e2