### PR TITLE
Add request state to share invite search

### DIFF
--- a/keep/src/main/java/com/keep/member/dto/MemberDTO.java
+++ b/keep/src/main/java/com/keep/member/dto/MemberDTO.java
@@ -19,6 +19,8 @@ public class MemberDTO {
         private String hname1;
         // 초대 가능 여부 표시용
         private boolean invitable;
+        // 요청 완료 여부 표시용
+        private boolean requested;
 	
 }
 

--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -56,11 +56,11 @@ public class MemberService {
 
         public java.util.List<MemberDTO> searchByName(String name) {
                 return memberRepository.searchByHname(name).stream()
-                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null, false)).toList();
+                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null, false, false)).toList();
         }
 
         public java.util.List<MemberDTO> searchAvailableForShare(Long scheduleId, String name) {
                 return memberRepository.searchAvailableForShare(scheduleId, name).stream()
-                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null, true)).toList();
+                                .map(e -> new MemberDTO(e.getId(), e.getEmail(), null, e.getHname(), null, true, false)).toList();
         }
 }

--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -20,11 +20,13 @@ public class ScheduleShareApiController {
 
         @GetMapping(path = "/search")
         public List<MemberDTO> searchAll(@RequestParam("name") String name, Authentication authentication) {
-                Long sharerId = Long.valueOf(authentication.getName());
-                List<Long> receivers = shareService.findReceiverIds(sharerId);
+                Long memberId = Long.valueOf(authentication.getName());
+                List<Long> receivers = shareService.findReceiverIds(memberId);
+                List<Long> requested = shareService.findSharerIds(memberId);
                 List<MemberDTO> members = memberService.searchByName(name);
                 for (MemberDTO dto : members) {
                         dto.setInvitable(!receivers.contains(dto.getId()));
+                        dto.setRequested(requested.contains(dto.getId()));
                 }
                 return members;
         }
@@ -54,7 +56,7 @@ public class ScheduleShareApiController {
                 Long sharerId = Long.parseLong(authentication.getName());
                 return shareService.findRequests(sharerId).stream()
                         .map(e -> new MemberDTO(e.getReceiverId(), null, null,
-                                memberService.findHnameById(e.getReceiverId()), null, false))
+                                memberService.findHnameById(e.getReceiverId()), null, false, false))
                         .toList();
         }
 
@@ -63,7 +65,7 @@ public class ScheduleShareApiController {
                 Long receiverId = Long.parseLong(authentication.getName());
                 return shareService.findInvites(receiverId).stream()
                         .map(e -> new MemberDTO(e.getSharerId(), null, null,
-                                memberService.findHnameById(e.getSharerId()), null, false))
+                                memberService.findHnameById(e.getSharerId()), null, false, false))
                         .toList();
         }
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -8,5 +8,6 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
     List<ScheduleShareEntity> findBySharerId(Long sharerId);
     List<ScheduleShareEntity> findBySharerIdAndAcceptYn(Long sharerId, String acceptYn);
     List<ScheduleShareEntity> findByReceiverIdAndAcceptYn(Long receiverId, String acceptYn);
+    List<ScheduleShareEntity> findByReceiverId(Long receiverId);
     boolean existsBySharerIdAndReceiverId(Long sharerId, Long receiverId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -19,6 +19,12 @@ public class ScheduleShareService {
                 .collect(Collectors.toList());
     }
 
+    public List<Long> findSharerIds(Long receiverId) {
+        return repository.findByReceiverId(receiverId).stream()
+                .map(ScheduleShareEntity::getSharerId)
+                .collect(Collectors.toList());
+    }
+
     public void invite(Long sharerId, Long receiverId) {
         if (!repository.existsBySharerIdAndReceiverId(sharerId, receiverId)) {
             ScheduleShareEntity entity = ScheduleShareEntity.builder()

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -29,14 +29,18 @@
 						button.className = 'invite-btn';
 						button.dataset.id = m.id;
 
-						if (!m.invitable) {
-							button.textContent = '초대완료';
-							button.disabled = true;
-							button.classList.add('disabled');
-						} else {
-							button.textContent = '초대하기';
-							button.addEventListener('click', () => {
-								fetch(`/api/share/invite`, {
+                                                if (m.requested) {
+                                                        button.textContent = '요청완료';
+                                                        button.disabled = true;
+                                                        button.classList.add('disabled');
+                                                } else if (!m.invitable) {
+                                                        button.textContent = '초대완료';
+                                                        button.disabled = true;
+                                                        button.classList.add('disabled');
+                                                } else {
+                                                        button.textContent = '초대하기';
+                                                        button.addEventListener('click', () => {
+                                                                fetch(`/api/share/invite`, {
 									method: 'POST',
 									headers: { 'Content-Type': 'application/json' },
 									body: JSON.stringify({ receiverId: m.id })


### PR DESCRIPTION
## Summary
- show users you've requested on invite search
- support requested flag in MemberDTO
- update ScheduleShare service/repo for receiver lookup

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850cb7edd908327b3c2db586fd2e4e9