### PR TITLE
Return DTOs from share service

### DIFF
--- a/keep/src/main/java/com/keep/share/mapper/ShareMapper.java
+++ b/keep/src/main/java/com/keep/share/mapper/ShareMapper.java
@@ -1,0 +1,20 @@
+package com.keep.share.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import com.keep.share.dto.ScheduleShareDTO;
+import com.keep.share.entity.ScheduleShareEntity;
+
+@Mapper(componentModel = "spring")
+public interface ShareMapper {
+    @Mapping(target = "scheduleShareId", source = "id")
+    ScheduleShareDTO toDto(ScheduleShareEntity entity);
+
+    @Mapping(target = "id", source = "scheduleShareId")
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "creationDate", ignore = true)
+    @Mapping(target = "lastUpdatedBy", ignore = true)
+    @Mapping(target = "lastUpdateDate", ignore = true)
+    @Mapping(target = "lastUpdateLogin", ignore = true)
+    ScheduleShareEntity toEntity(ScheduleShareDTO dto);
+}

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -1,7 +1,9 @@
 package com.keep.share.service;
 
+import com.keep.share.dto.ScheduleShareDTO;
 import com.keep.share.entity.ScheduleShareEntity;
 import com.keep.share.repository.ScheduleShareRepository;
+import com.keep.share.mapper.ShareMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +14,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ScheduleShareService {
     private final ScheduleShareRepository repository;
+    private final ShareMapper mapper;
 
     public List<Long> findReceiverIds(Long sharerId) {
         return repository.findBySharerId(sharerId).stream()
@@ -56,11 +59,15 @@ public class ScheduleShareService {
         }
     }
 
-    public List<ScheduleShareEntity> findRequests(Long sharerId) {
-        return repository.findBySharerIdAndAcceptYn(sharerId, "N");
+    public List<ScheduleShareDTO> findRequests(Long sharerId) {
+        return repository.findBySharerIdAndAcceptYn(sharerId, "N").stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
     }
 
-    public List<ScheduleShareEntity> findInvites(Long receiverId) {
-        return repository.findByReceiverIdAndAcceptYn(receiverId, "N");
+    public List<ScheduleShareDTO> findInvites(Long receiverId) {
+        return repository.findByReceiverIdAndAcceptYn(receiverId, "N").stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- convert `ScheduleShareService` methods to return `ScheduleShareDTO` instead of entities
- add `ShareMapper` and update service to use it

## Testing
- `./gradlew -p keep test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850cccc7ad48327b4a34c66711c7b99