### PR TITLE
Fix missing ShareMapper bean

### DIFF
--- a/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
+++ b/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
@@ -1,0 +1,39 @@
+package com.keep.share.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.keep.share.dto.ScheduleShareDTO;
+import com.keep.share.entity.ScheduleShareEntity;
+
+@Component
+public class ShareMapperImpl implements ShareMapper {
+    @Override
+    public ScheduleShareDTO toDto(ScheduleShareEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return ScheduleShareDTO.builder()
+                .scheduleShareId(entity.getId())
+                .sharerId(entity.getSharerId())
+                .receiverId(entity.getReceiverId())
+                .canEdit(entity.getCanEdit())
+                .acceptYn(entity.getAcceptYn())
+                .message(entity.getMessage())
+                .build();
+    }
+
+    @Override
+    public ScheduleShareEntity toEntity(ScheduleShareDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        return ScheduleShareEntity.builder()
+                .id(dto.getScheduleShareId())
+                .sharerId(dto.getSharerId())
+                .receiverId(dto.getReceiverId())
+                .canEdit(dto.getCanEdit())
+                .acceptYn(dto.getAcceptYn())
+                .message(dto.getMessage())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ShareMapperImpl` manually so it is a Spring bean

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850d246b4fc8327a95f2b30be5acedc