### PR TITLE
Implement share manage retrieval

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -43,4 +43,16 @@ public class ScheduleShareApiController {
                 return ResponseEntity.ok().build();
         }
 
+        @GetMapping("/manage/invite")
+        public List<ScheduleShareUserDTO> getInvites(Authentication authentication) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                return shareService.getPendingInvites(receiverId);
+        }
+
+        @GetMapping("/manage/request")
+        public List<ScheduleShareUserDTO> getRequests(Authentication authentication) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                return shareService.getPendingRequests(sharerId);
+        }
+
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -46,5 +46,41 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 			where lower(m.hname) like lower(concat('%', :name, '%'))
 			order by m.hname
 			""")
-	List<ScheduleShareUserDTO> searchAvailableForRequest(@Param("sharerId") Long sharerId, @Param("name") String name);
+        List<ScheduleShareUserDTO> searchAvailableForRequest(@Param("sharerId") Long sharerId, @Param("name") String name);
+
+        @Query("""
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.sharerId
+                        where s.receiverId = :receiverId
+                          and s.acceptYn = 'N'
+                        order by m.hname
+                        """)
+        List<ScheduleShareUserDTO> findPendingInvites(@Param("receiverId") Long receiverId);
+
+        @Query("""
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.receiverId
+                        where s.sharerId = :sharerId
+                          and s.acceptYn = 'N'
+                        order by m.hname
+                        """)
+        List<ScheduleShareUserDTO> findPendingRequests(@Param("sharerId") Long sharerId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -50,4 +50,12 @@ public class ScheduleShareService {
         return repository.searchAvailableForRequest(sharerId, name);
     }
 
+    public List<ScheduleShareUserDTO> getPendingInvites(Long receiverId) {
+        return repository.findPendingInvites(receiverId);
+    }
+
+    public List<ScheduleShareUserDTO> getPendingRequests(Long sharerId) {
+        return repository.findPendingRequests(sharerId);
+    }
+
 }

--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -27,15 +27,23 @@
                 div.className = 'list-item';
                 div.appendChild(document.createElement('span')).textContent = m.hname;
                 const action = document.createElement('div');
-                const acceptBtn = document.createElement('button');
-                acceptBtn.className = 'accept-btn';
-                acceptBtn.type = 'button';
-                acceptBtn.textContent = '수락';
+                const readBtn = document.createElement('button');
+                readBtn.className = 'accept-btn';
+                readBtn.type = 'button';
+                readBtn.textContent = '읽기만 허용';
+
+                const editBtn = document.createElement('button');
+                editBtn.className = 'accept-btn';
+                editBtn.type = 'button';
+                editBtn.textContent = '수정까지 허용';
+
                 const rejectBtn = document.createElement('button');
                 rejectBtn.className = 'reject-btn';
                 rejectBtn.type = 'button';
                 rejectBtn.textContent = '거절';
-                action.appendChild(acceptBtn);
+
+                action.appendChild(readBtn);
+                action.appendChild(editBtn);
                 action.appendChild(rejectBtn);
                 div.appendChild(action);
                 listContainer.appendChild(div);

--- a/keep/src/main/resources/templates/main/share/components/share-manage.html
+++ b/keep/src/main/resources/templates/main/share/components/share-manage.html
@@ -10,7 +10,8 @@
         <div class="list-item">
             <span>사용자 이름</span>
             <div>
-                <button class="accept-btn" type="button">수락</button>
+                <button class="accept-btn" type="button">읽기만 허용</button>
+                <button class="accept-btn" type="button">수정까지 허용</button>
                 <button class="reject-btn" type="button">거절</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add endpoints to fetch pending invites and requests
- add repository methods for retrieval
- expose retrieval through service
- adjust manage page buttons for different permissions
- update default HTML markup

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68526c435ce48327871c87d4c93add8b