### PR TITLE
Add scheduleShare flag for invitations and requests

### DIFF
--- a/keep/src/main/java/com/keep/share/dto/ScheduleShareDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/ScheduleShareDTO.java
@@ -17,4 +17,5 @@ public class ScheduleShareDTO {
     private String canEdit;
     private String acceptYn;
     private String message;
+    private String scheduleShare;
 }

--- a/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
+++ b/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
@@ -28,8 +28,11 @@ public class ScheduleShareEntity {
 	@Column(name = "CAN_EDIT")
 	private String canEdit;
 
-	@Column(name = "ACCEPT_YN")
-	private String acceptYn;
+        @Column(name = "ACCEPT_YN")
+        private String acceptYn;
+
+        @Column(name = "SCHEDULE_SHARE")
+        private String scheduleShare;
 	
 	@Lob
 	@Column(name = "MESSAGE")

--- a/keep/src/main/java/com/keep/share/mapper/ShareMapper.java
+++ b/keep/src/main/java/com/keep/share/mapper/ShareMapper.java
@@ -8,6 +8,7 @@ import com.keep.share.entity.ScheduleShareEntity;
 @Mapper(componentModel = "spring")
 public interface ShareMapper {
     @Mapping(target = "scheduleShareId", source = "id")
+    @Mapping(target = "scheduleShare", source = "scheduleShare")
     ScheduleShareDTO toDto(ScheduleShareEntity entity);
 
     @Mapping(target = "id", source = "scheduleShareId")
@@ -16,5 +17,6 @@ public interface ShareMapper {
     @Mapping(target = "lastUpdatedBy", ignore = true)
     @Mapping(target = "lastUpdateDate", ignore = true)
     @Mapping(target = "lastUpdateLogin", ignore = true)
+    @Mapping(target = "scheduleShare", source = "scheduleShare")
     ScheduleShareEntity toEntity(ScheduleShareDTO dto);
 }

--- a/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
+++ b/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
@@ -19,6 +19,7 @@ public class ShareMapperImpl implements ShareMapper {
                 .canEdit(entity.getCanEdit())
                 .acceptYn(entity.getAcceptYn())
                 .message(entity.getMessage())
+                .scheduleShare(entity.getScheduleShare())
                 .build();
     }
 
@@ -34,6 +35,7 @@ public class ShareMapperImpl implements ShareMapper {
                 .canEdit(dto.getCanEdit())
                 .acceptYn(dto.getAcceptYn())
                 .message(dto.getMessage())
+                .scheduleShare(dto.getScheduleShare())
                 .build();
     }
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -21,9 +21,10 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 			    case when s.id is null then true else false end
 			)
 			from MemberEntity m
-			left join ScheduleShareEntity s
-			  on s.sharerId = :sharerId
-			 and s.receiverId = m.id
+                        left join ScheduleShareEntity s
+                          on s.sharerId = :sharerId
+                         and s.receiverId = m.id
+                         and s.scheduleShare = 'I'
 			where lower(m.hname) like lower(concat('%', :name, '%'))
 			order by m.hname
 			""")
@@ -40,9 +41,10 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 			    case when s.id is null then true else false end
 			)
 			from MemberEntity m
-			left join ScheduleShareEntity s
-			  on s.receiverId = :sharerId
-			 and s.sharerId = m.id
+                        left join ScheduleShareEntity s
+                          on s.receiverId = :sharerId
+                         and s.sharerId = m.id
+                         and s.scheduleShare = 'R'
 			where lower(m.hname) like lower(concat('%', :name, '%'))
 			order by m.hname
 			""")
@@ -62,6 +64,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                         join MemberEntity m on m.id = s.sharerId
                         where s.receiverId = :receiverId
                           and s.acceptYn = 'N'
+                          and s.scheduleShare = 'I'
                         order by m.hname
                         """)
         List<ScheduleShareUserDTO> findPendingInvites(@Param("receiverId") Long receiverId);
@@ -80,6 +83,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                         join MemberEntity m on m.id = s.receiverId
                         where s.sharerId = :sharerId
                           and s.acceptYn = 'N'
+                          and s.scheduleShare = 'R'
                         order by m.hname
                         """)
         List<ScheduleShareUserDTO> findPendingRequests(@Param("sharerId") Long sharerId);

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -15,18 +15,34 @@ public class ScheduleShareService {
 	private final ScheduleShareRepository repository;
 	private final ShareMapper mapper;
 
-	public void invite(Long sharerId, Long receiverId) {
-		ScheduleShareEntity entity = ScheduleShareEntity.builder().sharerId(sharerId).receiverId(receiverId).canEdit("N")
-				.acceptYn("N").createdBy(sharerId).lastUpdatedBy(sharerId).lastUpdateLogin(sharerId).build();
-		repository.save(entity);
-	}
+        public void invite(Long sharerId, Long receiverId) {
+                ScheduleShareEntity entity = ScheduleShareEntity.builder()
+                                .sharerId(sharerId)
+                                .receiverId(receiverId)
+                                .canEdit("N")
+                                .acceptYn("N")
+                                .scheduleShare("I")
+                                .createdBy(sharerId)
+                                .lastUpdatedBy(sharerId)
+                                .lastUpdateLogin(sharerId)
+                                .build();
+                repository.save(entity);
+        }
 
-	public void request(Long sharerId, Long receiverId, String message) {
-		ScheduleShareEntity entity = ScheduleShareEntity.builder().sharerId(sharerId).receiverId(receiverId).canEdit("N")
-				.acceptYn("N").message(message).createdBy(receiverId).lastUpdatedBy(receiverId).lastUpdateLogin(receiverId)
-				.build();
-		repository.save(entity);
-	}
+        public void request(Long sharerId, Long receiverId, String message) {
+                ScheduleShareEntity entity = ScheduleShareEntity.builder()
+                                .sharerId(sharerId)
+                                .receiverId(receiverId)
+                                .canEdit("N")
+                                .acceptYn("N")
+                                .scheduleShare("R")
+                                .message(message)
+                                .createdBy(receiverId)
+                                .lastUpdatedBy(receiverId)
+                                .lastUpdateLogin(receiverId)
+                                .build();
+                repository.save(entity);
+        }
 
 	public List<ScheduleShareUserDTO> searchAvailableForInvite(Long sharerId, String name) {
 		return repository.searchAvailableForInvite(sharerId, name);


### PR DESCRIPTION
## Summary
- add `scheduleShare` field to `ScheduleShareEntity`
- map `scheduleShare` in DTO and mapper
- store `I` or `R` when inviting or requesting
- filter queries by share type

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68534a53871c83279e66cabf4ab353d7