### PR TITLE
Add bulk action buttons for share management

### DIFF
--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -3,6 +3,9 @@
     async function initShareManage() {
         const toggleBtns = document.querySelectorAll('.list-toggle .toggle-btn');
         const listContainer = document.querySelector('.list-container');
+        const acceptAllBtn = document.getElementById('accept-all-btn');
+        const rejectAllBtn = document.getElementById('reject-all-btn');
+        let currentType = 'request';
 
         async function fetchList(url) {
             try {
@@ -50,10 +53,27 @@
         }
 
         async function load(type) {
+            currentType = type;
             const url = type === 'request' ? '/api/share/manage/requests' : '/api/share/manage/invitations';
             const data = await fetchList(url);
             render(data);
         }
+
+        acceptAllBtn?.addEventListener('click', async () => {
+            const url = currentType === 'request'
+                ? '/api/share/manage/requests/accept-all'
+                : '/api/share/manage/invitations/accept-all';
+            await fetch(url, { method: 'POST' });
+            load(currentType);
+        });
+
+        rejectAllBtn?.addEventListener('click', async () => {
+            const url = currentType === 'request'
+                ? '/api/share/manage/requests/reject-all'
+                : '/api/share/manage/invitations/reject-all';
+            await fetch(url, { method: 'POST' });
+            load(currentType);
+        });
 
         toggleBtns.forEach(btn => {
             btn.addEventListener('click', () => {

--- a/keep/src/main/resources/templates/main/share/components/share-manage.html
+++ b/keep/src/main/resources/templates/main/share/components/share-manage.html
@@ -6,6 +6,10 @@
         <button class="toggle-btn active" data-target="request">받은 요청</button>
         <button class="toggle-btn" data-target="invite">받은 초대</button>
     </div>
+    <div class="batch-actions">
+        <button class="accept-btn" id="accept-all-btn" type="button">일괄 승락</button>
+        <button class="reject-btn" id="reject-all-btn" type="button">일괄 거절</button>
+    </div>
     <div class="list-container">
         <div class="list-item">
             <span>사용자 이름</span>


### PR DESCRIPTION
## Summary
- add a bulk action area to manage shares
- support 'accept all' and 'reject all' interactions in the JS

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68534e73440c8327a1812dc1386945a5