### PR TITLE
Add share list loading API and UI

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -69,10 +69,24 @@ public class ScheduleShareApiController {
 	// —————————————————————————————————————————————————————————
 	// 6) 조회: 내가 받은 초대(Invitation) 목록 조회
 	// —————————————————————————————————————————————————————————
-	@GetMapping("/manage/invitations")
-	public List<ScheduleShareUserDTO> listReceivedInvitations(Authentication authentication) {
-		Long receiverId = Long.valueOf(authentication.getName());
-		return shareService.searchReceivedInvitations(receiverId);
-	}
+        @GetMapping("/manage/invitations")
+        public List<ScheduleShareUserDTO> listReceivedInvitations(Authentication authentication) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                return shareService.searchReceivedInvitations(receiverId);
+        }
+
+        // —————————————————————————————————————————————————————————
+        // 7) 조회: 공유 목록(공유한/공유받은)
+        // —————————————————————————————————————————————————————————
+        @GetMapping("/list")
+        public List<ScheduleShareUserDTO> listShares(@RequestParam("type") String type,
+                                                     Authentication authentication) {
+                Long userId = Long.valueOf(authentication.getName());
+                if ("shared".equals(type)) {
+                        return shareService.listShared(userId);
+                } else {
+                        return shareService.listReceived(userId);
+                }
+        }
 
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -87,4 +87,40 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                         order by m.hname
                         """)
         List<ScheduleShareUserDTO> findPendingRequests(@Param("sharerId") Long sharerId);
+
+        @Query("""
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.receiverId
+                        where s.sharerId = :sharerId
+                          and s.acceptYn = 'Y'
+                        order by m.hname
+                        """)
+        List<ScheduleShareUserDTO> findAcceptedShares(@Param("sharerId") Long sharerId);
+
+        @Query("""
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.sharerId
+                        where s.receiverId = :receiverId
+                          and s.acceptYn = 'Y'
+                        order by m.hname
+                        """)
+        List<ScheduleShareUserDTO> findAcceptedReceived(@Param("receiverId") Long receiverId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -56,8 +56,16 @@ public class ScheduleShareService {
 		return repository.findPendingRequests(shareId);
 	}
 
-	public List<ScheduleShareUserDTO> searchReceivedInvitations(Long receiverId) {
-		return repository.findPendingInvites(receiverId);
-	}
+        public List<ScheduleShareUserDTO> searchReceivedInvitations(Long receiverId) {
+                return repository.findPendingInvites(receiverId);
+        }
+
+        public List<ScheduleShareUserDTO> listShared(Long sharerId) {
+                return repository.findAcceptedShares(sharerId);
+        }
+
+        public List<ScheduleShareUserDTO> listReceived(Long receiverId) {
+                return repository.findAcceptedReceived(receiverId);
+        }
 
 }

--- a/keep/src/main/resources/static/css/main/share/share.css
+++ b/keep/src/main/resources/static/css/main/share/share.css
@@ -112,6 +112,10 @@
   color: #fff;
   margin-right: 4px;
 }
+.accept-btn.disabled {
+  background-color: #666;
+  cursor: not-allowed;
+}
 .reject-btn {
   background-color: #e5e7eb;
 }

--- a/keep/src/main/resources/static/js/main/share/components/share-list.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-list.js
@@ -19,6 +19,33 @@
                     const div = document.createElement('div');
                     div.className = 'list-item';
                     div.appendChild(document.createElement('span')).textContent = m.hname;
+
+                    const action = document.createElement('div');
+                    const readBtn = document.createElement('button');
+                    readBtn.className = 'accept-btn';
+                    readBtn.type = 'button';
+                    readBtn.textContent = '읽기';
+                    const editBtn = document.createElement('button');
+                    editBtn.className = 'accept-btn';
+                    editBtn.type = 'button';
+                    editBtn.textContent = '수정';
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'reject-btn';
+                    delBtn.type = 'button';
+                    delBtn.textContent = '권한 삭제';
+
+                    if (m.canEdit === 'Y') {
+                        editBtn.disabled = true;
+                        editBtn.classList.add('disabled');
+                    } else {
+                        readBtn.disabled = true;
+                        readBtn.classList.add('disabled');
+                    }
+
+                    action.appendChild(readBtn);
+                    action.appendChild(editBtn);
+                    action.appendChild(delBtn);
+                    div.appendChild(action);
                     listEl.appendChild(div);
                 });
             } catch (e) {


### PR DESCRIPTION
## Summary
- implement API endpoint `/api/share/list` to load accepted share lists
- add service and repository methods for accepted shares
- display action buttons in share list UI
- style disabled state for accept button

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68534f16816c8327b37c6161e98cb3d2