### PR TITLE
Enhance invite options with read/edit choices

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -30,12 +30,13 @@ public class ScheduleShareApiController {
 	// —————————————————————————————————————————————————————————
 	// 2) 실행: 사용자에게 초대 보내기
 	// —————————————————————————————————————————————————————————
-	@PostMapping("/invite")
-	public ResponseEntity<Void> sendInvitation(Authentication authentication, @RequestBody ScheduleShareDTO dto) {
-		Long sharerId = Long.valueOf(authentication.getName());
-		shareService.invite(sharerId, dto.getReceiverId());
-		return ResponseEntity.ok().build();
-	}
+        @PostMapping("/invite")
+        public ResponseEntity<Void> sendInvitation(Authentication authentication, @RequestBody ScheduleShareDTO dto) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                String canEdit = dto.getCanEdit() == null ? "N" : dto.getCanEdit();
+                shareService.invite(sharerId, dto.getReceiverId(), canEdit);
+                return ResponseEntity.ok().build();
+        }
 
 	// —————————————————————————————————————————————————————————
 	// 3) 검색: 내가 요청할 수 있는 유저 목록 조회

--- a/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
@@ -29,4 +29,7 @@ public class ScheduleShareUserDTO {
 
     /** 초대 가능 여부 */
     Boolean invitable;
+
+    /** 나에게 요청했는지 여부 */
+    Boolean requested;
 }

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -11,35 +11,42 @@ import java.util.List;
 public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEntity, Long> {
 
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    case when s.id is null then true else false end
-			)
-			from MemberEntity m
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            case when s.id is null then true else false end,
+                            case when r.id is not null then true else false end
+                        )
+                        from MemberEntity m
                         left join ScheduleShareEntity s
                           on s.sharerId = :sharerId
                          and s.receiverId = m.id
                          and s.actionType = 'I'
-			where lower(m.hname) like lower(concat('%', :name, '%'))
-			order by m.hname
+                        left join ScheduleShareEntity r
+                          on r.sharerId = m.id
+                         and r.receiverId = :sharerId
+                         and r.actionType = 'R'
+                         and r.acceptYn = 'N'
+                        where lower(m.hname) like lower(concat('%', :name, '%'))
+                        order by m.hname
 			""")
 	List<ScheduleShareUserDTO> searchAvailableForInvite(@Param("sharerId") Long sharerId, @Param("name") String name);
 	
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    case when s.id is null then true else false end
-			)
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            case when s.id is null then true else false end,
+                            false
+                        )
 			from MemberEntity m
                         left join ScheduleShareEntity s
                           on s.receiverId = :sharerId
@@ -58,6 +65,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                             s.acceptYn,
                             m.id,
                             m.hname,
+                            false,
                             false
                         )
                         from ScheduleShareEntity s
@@ -77,6 +85,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                             s.acceptYn,
                             m.id,
                             m.hname,
+                            false,
                             false
                         )
                         from ScheduleShareEntity s
@@ -96,6 +105,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                             s.acceptYn,
                             m.id,
                             m.hname,
+                            false,
                             false
                         )
                         from ScheduleShareEntity s
@@ -114,6 +124,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                             s.acceptYn,
                             m.id,
                             m.hname,
+                            false,
                             false
                         )
                         from ScheduleShareEntity s

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -15,11 +15,11 @@ public class ScheduleShareService {
 	private final ScheduleShareRepository repository;
 	private final ShareMapper mapper;
 
-        public void invite(Long sharerId, Long receiverId) {
+        public void invite(Long sharerId, Long receiverId, String canEdit) {
                 ScheduleShareEntity entity = ScheduleShareEntity.builder()
                                 .sharerId(sharerId)
                                 .receiverId(receiverId)
-                                .canEdit("N")
+                                .canEdit(canEdit)
                                 .acceptYn("N")
                                 .actionType("I")
                                 .createdBy(sharerId)


### PR DESCRIPTION
## Summary
- add `requested` flag to `ScheduleShareUserDTO`
- mark pending requests in repository queries
- allow specifying edit rights when inviting
- adjust controller to forward `canEdit`
- show read/edit invite buttons and controls for requested users

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853957d97b08327bb346866fb6b0fb3