### PR TITLE
Add share management actions

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -76,6 +76,71 @@ public class ScheduleShareApiController {
                 return shareService.searchReceivedInvitations(receiverId);
         }
 
+        // ------------------------------------------------------------------
+        // 6-1) 개별/일괄 처리 APIs
+        // ------------------------------------------------------------------
+
+        @PostMapping("/manage/requests/accept")
+        public ResponseEntity<Void> acceptRequest(Authentication authentication,
+                                                  @RequestBody ScheduleShareDTO dto) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                shareService.acceptRequest(sharerId, dto.getReceiverId(),
+                        dto.getCanEdit() == null ? "N" : dto.getCanEdit());
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/requests/reject")
+        public ResponseEntity<Void> rejectRequest(Authentication authentication,
+                                                  @RequestBody ScheduleShareDTO dto) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                shareService.rejectRequest(sharerId, dto.getReceiverId());
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/invitations/accept")
+        public ResponseEntity<Void> acceptInvitation(Authentication authentication,
+                                                     @RequestBody ScheduleShareDTO dto) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.acceptInvitation(dto.getSharerId(), receiverId);
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/invitations/reject")
+        public ResponseEntity<Void> rejectInvitation(Authentication authentication,
+                                                     @RequestBody ScheduleShareDTO dto) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.rejectInvitation(dto.getSharerId(), receiverId);
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/requests/accept-all")
+        public ResponseEntity<Void> acceptAllRequests(Authentication authentication) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                shareService.acceptAllRequests(sharerId);
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/requests/reject-all")
+        public ResponseEntity<Void> rejectAllRequests(Authentication authentication) {
+                Long sharerId = Long.valueOf(authentication.getName());
+                shareService.rejectAllRequests(sharerId);
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/invitations/accept-all")
+        public ResponseEntity<Void> acceptAllInvitations(Authentication authentication) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.acceptAllInvitations(receiverId);
+                return ResponseEntity.ok().build();
+        }
+
+        @PostMapping("/manage/invitations/reject-all")
+        public ResponseEntity<Void> rejectAllInvitations(Authentication authentication) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.rejectAllInvitations(receiverId);
+                return ResponseEntity.ok().build();
+        }
+
         // —————————————————————————————————————————————————————————
         // 7) 조회: 공유 목록(공유한/공유받은)
         // —————————————————————————————————————————————————————————

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -4,6 +4,7 @@ import com.keep.share.dto.ScheduleShareUserDTO;
 import com.keep.share.entity.ScheduleShareEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -134,4 +135,57 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
                         order by m.hname
                         """)
         List<ScheduleShareUserDTO> findAcceptedReceived(@Param("receiverId") Long receiverId);
+
+        // ------------------------------------------------------------------
+        // Update operations for managing requests/invitations
+        // ------------------------------------------------------------------
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.canEdit=:canEdit, s.acceptYn='Y' " +
+               "where s.sharerId=:sharerId and s.receiverId=:receiverId " +
+               "and s.actionType='R' and s.acceptYn='N'")
+        int acceptRequest(@Param("sharerId") Long sharerId,
+                          @Param("receiverId") Long receiverId,
+                          @Param("canEdit") String canEdit);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='R' " +
+               "where s.sharerId=:sharerId and s.receiverId=:receiverId " +
+               "and s.actionType='R' and s.acceptYn='N'")
+        int rejectRequest(@Param("sharerId") Long sharerId,
+                          @Param("receiverId") Long receiverId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='Y' " +
+               "where s.sharerId=:sharerId and s.receiverId=:receiverId " +
+               "and s.actionType='I' and s.acceptYn='N'")
+        int acceptInvitation(@Param("sharerId") Long sharerId,
+                             @Param("receiverId") Long receiverId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='R' " +
+               "where s.sharerId=:sharerId and s.receiverId=:receiverId " +
+               "and s.actionType='I' and s.acceptYn='N'")
+        int rejectInvitation(@Param("sharerId") Long sharerId,
+                             @Param("receiverId") Long receiverId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='Y' " +
+               "where s.sharerId=:sharerId and s.actionType='R' and s.acceptYn='N'")
+        int acceptAllRequests(@Param("sharerId") Long sharerId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='R' " +
+               "where s.sharerId=:sharerId and s.actionType='R' and s.acceptYn='N'")
+        int rejectAllRequests(@Param("sharerId") Long sharerId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='Y' " +
+               "where s.receiverId=:receiverId and s.actionType='I' and s.acceptYn='N'")
+        int acceptAllInvitations(@Param("receiverId") Long receiverId);
+
+        @Modifying
+        @Query("update ScheduleShareEntity s set s.acceptYn='R' " +
+               "where s.receiverId=:receiverId and s.actionType='I' and s.acceptYn='N'")
+        int rejectAllInvitations(@Param("receiverId") Long receiverId);
 }

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -6,6 +6,7 @@ import com.keep.share.repository.ScheduleShareRepository;
 import com.keep.share.mapper.ShareMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -66,6 +67,50 @@ public class ScheduleShareService {
 
         public List<ScheduleShareUserDTO> listReceived(Long receiverId) {
                 return repository.findAcceptedReceived(receiverId);
+        }
+
+        // ------------------------------------------------------------------
+        // Manage requests and invitations
+        // ------------------------------------------------------------------
+
+        @Transactional
+        public void acceptRequest(Long sharerId, Long receiverId, String canEdit) {
+                repository.acceptRequest(sharerId, receiverId, canEdit);
+        }
+
+        @Transactional
+        public void rejectRequest(Long sharerId, Long receiverId) {
+                repository.rejectRequest(sharerId, receiverId);
+        }
+
+        @Transactional
+        public void acceptInvitation(Long sharerId, Long receiverId) {
+                repository.acceptInvitation(sharerId, receiverId);
+        }
+
+        @Transactional
+        public void rejectInvitation(Long sharerId, Long receiverId) {
+                repository.rejectInvitation(sharerId, receiverId);
+        }
+
+        @Transactional
+        public void acceptAllRequests(Long sharerId) {
+                repository.acceptAllRequests(sharerId);
+        }
+
+        @Transactional
+        public void rejectAllRequests(Long sharerId) {
+                repository.rejectAllRequests(sharerId);
+        }
+
+        @Transactional
+        public void acceptAllInvitations(Long receiverId) {
+                repository.acceptAllInvitations(receiverId);
+        }
+
+        @Transactional
+        public void rejectAllInvitations(Long receiverId) {
+                repository.rejectAllInvitations(receiverId);
         }
 
 }

--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -29,24 +29,81 @@
                 div.className = 'list-item';
                 div.appendChild(document.createElement('span')).textContent = m.hname;
                 const action = document.createElement('div');
-                const readBtn = document.createElement('button');
-                readBtn.className = 'accept-btn';
-                readBtn.type = 'button';
-                readBtn.textContent = '읽기만 허용';
 
-                const editBtn = document.createElement('button');
-                editBtn.className = 'accept-btn';
-                editBtn.type = 'button';
-                editBtn.textContent = '수정까지 허용';
+                if (currentType === 'request') {
+                    const readBtn = document.createElement('button');
+                    readBtn.className = 'accept-btn';
+                    readBtn.type = 'button';
+                    readBtn.textContent = '읽기만 허용';
+                    readBtn.addEventListener('click', async () => {
+                        await fetch('/api/share/manage/requests/accept', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ receiverId: m.id, canEdit: 'N' })
+                        });
+                        load(currentType);
+                    });
 
-                const rejectBtn = document.createElement('button');
-                rejectBtn.className = 'reject-btn';
-                rejectBtn.type = 'button';
-                rejectBtn.textContent = '거절';
+                    const editBtn = document.createElement('button');
+                    editBtn.className = 'accept-btn';
+                    editBtn.type = 'button';
+                    editBtn.textContent = '수정까지 허용';
+                    editBtn.addEventListener('click', async () => {
+                        await fetch('/api/share/manage/requests/accept', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ receiverId: m.id, canEdit: 'Y' })
+                        });
+                        load(currentType);
+                    });
 
-                action.appendChild(readBtn);
-                action.appendChild(editBtn);
-                action.appendChild(rejectBtn);
+                    const rejectBtn = document.createElement('button');
+                    rejectBtn.className = 'reject-btn';
+                    rejectBtn.type = 'button';
+                    rejectBtn.textContent = '거절';
+                    rejectBtn.addEventListener('click', async () => {
+                        await fetch('/api/share/manage/requests/reject', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ receiverId: m.id })
+                        });
+                        load(currentType);
+                    });
+
+                    action.appendChild(readBtn);
+                    action.appendChild(editBtn);
+                    action.appendChild(rejectBtn);
+                } else {
+                    const acceptBtn = document.createElement('button');
+                    acceptBtn.className = 'accept-btn';
+                    acceptBtn.type = 'button';
+                    acceptBtn.textContent = '수락';
+                    acceptBtn.addEventListener('click', async () => {
+                        await fetch('/api/share/manage/invitations/accept', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ sharerId: m.id })
+                        });
+                        load(currentType);
+                    });
+
+                    const rejectBtn = document.createElement('button');
+                    rejectBtn.className = 'reject-btn';
+                    rejectBtn.type = 'button';
+                    rejectBtn.textContent = '거절';
+                    rejectBtn.addEventListener('click', async () => {
+                        await fetch('/api/share/manage/invitations/reject', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ sharerId: m.id })
+                        });
+                        load(currentType);
+                    });
+
+                    action.appendChild(acceptBtn);
+                    action.appendChild(rejectBtn);
+                }
+
                 div.appendChild(action);
                 listContainer.appendChild(div);
             });


### PR DESCRIPTION
## Summary
- implement per-item and bulk accept/reject APIs for share requests and invitations
- expose new endpoints in `ScheduleShareApiController`
- add repository update queries and service wrappers
- enhance `share-manage.js` to call the new APIs when clicking buttons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685399c28330832782615c7f18dddd71