### PR TITLE
Update share invite workflow to use ScheduleShare ID

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
+++ b/keep/src/main/java/com/keep/share/controller/ScheduleShareApiController.java
@@ -67,19 +67,19 @@ public class ScheduleShareApiController {
 		return shareService.searchReceivedRequests(shareId);
 	}
 
-	@PostMapping("/manage/requests/accept")
-	public ResponseEntity<Void> acceptRequest(Authentication authentication, @RequestBody ScheduleShareDTO dto) {
-		Long receiverId = Long.valueOf(authentication.getName());
-		shareService.acceptRequest(dto.getSharerId(), receiverId, dto.getCanEdit());
-		return ResponseEntity.ok().build();
-	}
+        @PostMapping("/manage/requests/accept")
+        public ResponseEntity<Void> acceptRequest(Authentication authentication, @RequestBody ScheduleShareDTO dto) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.acceptRequest(dto.getScheduleShareId(), receiverId, dto.getCanEdit());
+                return ResponseEntity.ok().build();
+        }
 
-	@DeleteMapping("/manage/requests")
-	public ResponseEntity<Void> rejectRequest(Authentication authentication, @RequestParam("sharerId") Long sharerId) {
-		Long receiverId = Long.valueOf(authentication.getName());
-		shareService.deleteRequest(sharerId, receiverId);
-		return ResponseEntity.ok().build();
-	}
+        @DeleteMapping("/manage/requests")
+        public ResponseEntity<Void> rejectRequest(Authentication authentication, @RequestParam("scheduleShareId") Long scheduleShareId) {
+                Long receiverId = Long.valueOf(authentication.getName());
+                shareService.deleteRequest(scheduleShareId, receiverId);
+                return ResponseEntity.ok().build();
+        }
 
 	// —————————————————————————————————————————————————————————
 	// 6) 조회: 내가 받은 초대(Invitation) 목록 조회

--- a/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
@@ -9,6 +9,9 @@ import lombok.Value;
 @Value
 @Builder
 public class ScheduleShareUserDTO {
+    /** 스케줄 공유 ID */
+    Long scheduleShareId;
+
     /** 초대자 ID */
     Long sharerId;
 

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -12,6 +12,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
 	@Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            r.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,
@@ -39,6 +40,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 	
 	@Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,
@@ -61,6 +63,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         @Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,
@@ -81,6 +84,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         @Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,
@@ -101,6 +105,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         @Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,
@@ -120,6 +125,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         @Query("""
                         select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
                             s.sharerId,
                             s.receiverId,
                             s.canEdit,

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -54,21 +54,24 @@ public class ScheduleShareService {
 		return repository.findAcceptedReceived(receiverId);
 	}
 
-	@Transactional
-	public void acceptRequest(Long sharerId, Long receiverId, String canEdit) {
-		repository.findFirstBySharerIdAndReceiverIdAndActionTypeAndAcceptYn(sharerId, receiverId, "R", "N")
-				.ifPresent(entity -> {
-					entity.setAcceptYn("Y");
-					if ("Y".equals(canEdit)) {
-						entity.setCanEdit("Y");
-					}
-					repository.save(entity);
-				});
-	}
+        @Transactional
+        public void acceptRequest(Long scheduleShareId, Long receiverId, String canEdit) {
+                repository.findById(scheduleShareId)
+                        .filter(entity -> entity.getReceiverId().equals(receiverId))
+                        .ifPresent(entity -> {
+                                entity.setAcceptYn("Y");
+                                if ("Y".equals(canEdit)) {
+                                        entity.setCanEdit("Y");
+                                }
+                                repository.save(entity);
+                        });
+        }
 
-	@Transactional
-	public void deleteRequest(Long sharerId, Long receiverId) {
-		repository.deleteBySharerIdAndReceiverIdAndActionType(sharerId, receiverId, "R");
-	}
+        @Transactional
+        public void deleteRequest(Long scheduleShareId, Long receiverId) {
+                repository.findById(scheduleShareId)
+                        .filter(entity -> entity.getReceiverId().equals(receiverId))
+                        .ifPresent(repository::delete);
+        }
 
 }

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -59,7 +59,7 @@
                                 const res = await fetch('/api/share/manage/requests');
                                 if (!res.ok) throw new Error('network');
                                 const data = await res.json();
-                                const m = data.find(u => String(u.sharerId) === String(scheduleShareId));
+                const m = data.find(u => String(u.scheduleShareId) === String(scheduleShareId));
                                 if (m) {
                                         list.innerHTML = '';
                                         list.style.minHeight = 'auto';
@@ -87,7 +87,7 @@
                                                 fetch('/api/share/manage/requests/accept', {
                                                         method: 'POST',
                                                         headers: { 'Content-Type': 'application/json' },
-                                                        body: JSON.stringify({ sharerId: m.id, canEdit: 'N' })
+                                                        body: JSON.stringify({ scheduleShareId: m.scheduleShareId, canEdit: 'N' })
                                                 }).then(res => {
                                                         if (res.ok) {
                                                                 editBtn.remove();
@@ -102,7 +102,7 @@
                                                 fetch('/api/share/manage/requests/accept', {
                                                         method: 'POST',
                                                         headers: { 'Content-Type': 'application/json' },
-                                                        body: JSON.stringify({ sharerId: m.id, canEdit: 'Y' })
+                                                        body: JSON.stringify({ scheduleShareId: m.scheduleShareId, canEdit: 'Y' })
                                                 }).then(res => {
                                                         if (res.ok) {
                                                                 readBtn.remove();
@@ -114,7 +114,7 @@
                                         });
 
                                         rejectBtn.addEventListener('click', () => {
-                                                fetch(`/api/share/manage/requests?sharerId=${m.id}`, { method: 'DELETE' })
+                                                fetch(`/api/share/manage/requests?scheduleShareId=${m.scheduleShareId}`, { method: 'DELETE' })
                                                         .then(res => {
                                                                 if (res.ok) {
                                                                         action.innerHTML = '';
@@ -177,11 +177,11 @@
 								rejectBtn.textContent = '거절';
 
 								readBtn.addEventListener('click', () => {
-									fetch('/api/share/manage/requests/accept', {
-										method: 'POST',
-										headers: { 'Content-Type': 'application/json' },
-										body: JSON.stringify({ sharerId: m.id, canEdit: 'N' })
-									}).then(res => {
+                                                                        fetch('/api/share/manage/requests/accept', {
+                                                                               method: 'POST',
+                                                                               headers: { 'Content-Type': 'application/json' },
+                                                                               body: JSON.stringify({ scheduleShareId: m.scheduleShareId, canEdit: 'N' })
+                                                                        }).then(res => {
 										if (res.ok) {
 											editBtn.remove();
 											rejectBtn.remove();
@@ -191,11 +191,11 @@
 									});
 								});
 								editBtn.addEventListener('click', () => {
-									fetch('/api/share/manage/requests/accept', {
-										method: 'POST',
-										headers: { 'Content-Type': 'application/json' },
-										body: JSON.stringify({ sharerId: m.id, canEdit: 'Y' })
-									}).then(res => {
+                                                                        fetch('/api/share/manage/requests/accept', {
+                                                                               method: 'POST',
+                                                                               headers: { 'Content-Type': 'application/json' },
+                                                                               body: JSON.stringify({ scheduleShareId: m.scheduleShareId, canEdit: 'Y' })
+                                                                        }).then(res => {
 										if (res.ok) {
 											readBtn.remove();
 											rejectBtn.remove();
@@ -206,8 +206,8 @@
 								});
 
 								rejectBtn.addEventListener('click', () => {
-									fetch(`/api/share/manage/requests?sharerId=${m.id}`, { method: 'DELETE' })
-										.then(res => {
+                                                                        fetch(`/api/share/manage/requests?scheduleShareId=${m.scheduleShareId}`, { method: 'DELETE' })
+                                                                               .then(res => {
 											if (res.ok) {
 												action.innerHTML = '';
 												createInviteButtons(action, m.id);


### PR DESCRIPTION
## Summary
- expose `scheduleShareId` in `ScheduleShareUserDTO`
- join with `ScheduleShare` when searching for requests or invites
- update service and controller to accept/delete requests by ID
- adjust invite JS to send scheduleShareId to API

## Testing
- `gradle test` *(fails: could not resolve Spring Boot plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6853b5692e648327ad62c83f42f3b43c