### PR TITLE
Add toast notifications for share invite actions

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -62,3 +62,21 @@
 #invite-list .list-item:last-child {
   border-bottom: 1px solid #ddd;
 }
+
+.invite-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  background: #323232;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 200;
+}
+
+.invite-toast.show {
+  opacity: 1;
+}

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -35,20 +35,35 @@
             target.appendChild(done);
         }
 
-        async function handleAccept(id, canEdit, container) {
+        function showToast(message, duration = 3000) {
+            const toast = document.createElement('div');
+            toast.className = 'invite-toast';
+            toast.textContent = message;
+            document.body.appendChild(toast);
+            requestAnimationFrame(() => toast.classList.add('show'));
+            setTimeout(() => {
+                toast.classList.remove('show');
+                toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+            }, duration);
+        }
+
+        async function handleAccept(id, canEdit, container, name) {
             await fetch('/api/share/manage/requests/accept', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ scheduleShareId: id, canEdit })
             });
             replaceWithDone(container);
+            const perm = canEdit === 'Y' ? '수정' : '읽기';
+            showToast(`${name}에게 ${perm} 권한이 부여되었습니다.`);
         }
 
-        async function handleReject(id, container) {
+        async function handleReject(id, container, name) {
             await fetch(`/api/share/manage/requests?scheduleShareId=${id}`, {
                 method: 'DELETE'
             });
-            replaceWithDone(container);
+            replaceWithDone(container, '거절완료');
+            showToast(`${name}의 요청을 거절했습니다.`);
         }
 
         btn?.addEventListener('click', () => {
@@ -83,7 +98,7 @@
                             readBtn.type = 'button';
                             readBtn.textContent = '읽기';
                             readBtn.addEventListener('click', () => {
-                                handleAccept(m.scheduleShareId, 'N', action);
+                                handleAccept(m.scheduleShareId, 'N', action, m.hname);
                             });
 
                             const editBtn = document.createElement('button');
@@ -91,7 +106,7 @@
                             editBtn.type = 'button';
                             editBtn.textContent = '수정';
                             editBtn.addEventListener('click', () => {
-                                handleAccept(m.scheduleShareId, 'Y', action);
+                                handleAccept(m.scheduleShareId, 'Y', action, m.hname);
                             });
 
                             const rejectBtn = document.createElement('button');
@@ -99,7 +114,7 @@
                             rejectBtn.type = 'button';
                             rejectBtn.textContent = '거절';
                             rejectBtn.addEventListener('click', () => {
-                                handleReject(m.scheduleShareId, action);
+                                handleReject(m.scheduleShareId, action, m.hname);
                             });
 
                             action.appendChild(readBtn);
@@ -122,6 +137,7 @@
                                             inviteBtn.textContent = '초대완료';
                                             inviteBtn.disabled = true;
                                             inviteBtn.classList.add('disabled');
+                                            showToast(`${m.hname}에게 초대가 완료되었습니다.`);
                                         }
                                     });
                                 });


### PR DESCRIPTION
## Summary
- show toast messages when approving, rejecting, or inviting members
- add invite toast styles

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf0819408327871469d77dc3e8b8