### PR TITLE
Fix duplicate click events in share manage

### DIFF
--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -145,12 +145,15 @@
 			render(data, type);
 		}
 
-		toggleBtns.forEach(btn => {
-			btn.addEventListener('click', () => {
-				toggleBtns.forEach(b => b.classList.toggle('active', b === btn));
-				load(btn.dataset.target);
-			});
-		});
+                toggleBtns.forEach(btn => {
+                        if (!btn.dataset.listenerAttached) {
+                                btn.addEventListener('click', () => {
+                                        toggleBtns.forEach(b => b.classList.toggle('active', b === btn));
+                                        load(btn.dataset.target);
+                                });
+                                btn.dataset.listenerAttached = 'true';
+                        }
+                });
 
 		// default view
 		load('request');


### PR DESCRIPTION
## Summary
- avoid re-adding click handlers in share-manage.js

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6858e24a2e3c8327a75b19ab15d13f55