### PR TITLE
Fix missing ScheduleMapper bean

### DIFF
--- a/keep/src/main/java/com/keep/schedule/mapper/ScheduleMapperImpl.java
+++ b/keep/src/main/java/com/keep/schedule/mapper/ScheduleMapperImpl.java
@@ -1,0 +1,61 @@
+package com.keep.schedule.mapper;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.springframework.stereotype.Component;
+
+import com.keep.schedule.dto.ScheduleDTO;
+import com.keep.schedule.entity.ScheduleEntity;
+
+@Component
+public class ScheduleMapperImpl implements ScheduleMapper {
+
+    @Override
+    public ScheduleEntity toEntity(ScheduleDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        ScheduleEntity.ScheduleEntityBuilder builder = ScheduleEntity.builder();
+        builder.schedulesId(dto.getSchedulesId());
+        builder.userId(dto.getUserId());
+        builder.title(dto.getTitle());
+        builder.location(dto.getLocation());
+        builder.description(dto.getDescription());
+        builder.category(dto.getCategory());
+        builder.fileUrl(dto.getFileUrl());
+        builder.lastUpdatedBy(dto.getUserId());
+        builder.createdBy(dto.getUserId());
+        builder.startTs(LocalDateTime.of(dto.getStartDay(), LocalTime.of(dto.getStartHour(), dto.getStartMin())));
+        builder.endTs(LocalDateTime.of(dto.getEndDay(), LocalTime.of(dto.getEndHour(), dto.getEndMin())));
+        return builder.build();
+    }
+
+    @Override
+    public ScheduleDTO toDto(ScheduleEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        ScheduleDTO.ScheduleDTOBuilder builder = ScheduleDTO.builder();
+        builder.userId(entity.getUserId());
+        builder.schedulesId(entity.getSchedulesId());
+        builder.title(entity.getTitle());
+        builder.location(entity.getLocation());
+        builder.description(entity.getDescription());
+        builder.category(entity.getCategory());
+        builder.fileUrl(entity.getFileUrl());
+        LocalDateTime st = entity.getStartTs();
+        LocalDateTime et = entity.getEndTs();
+        if (st != null) {
+            builder.startDay(st.toLocalDate());
+            builder.startHour(st.getHour());
+            builder.startMin(st.getMinute());
+        }
+        if (et != null) {
+            builder.endDay(et.toLocalDate());
+            builder.endHour(et.getHour());
+            builder.endMin(et.getMinute());
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ScheduleMapperImpl` manually so Spring can inject the mapper

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb352db08327befd35c51fef9863