### PR TITLE
Fix tests by adding missing security dependency

### DIFF
--- a/keep/build.gradle
+++ b/keep/build.gradle
@@ -43,8 +43,9 @@ dependencies {
 	
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	
 }
 // --- 여기에 추가 ---


### PR DESCRIPTION
## Summary
- add the `spring-security-test` library for unit tests

## Testing
- `gradle test` *(fails: could not download Gradle plugins because the environment lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd5377908327923fea30e17d7268