### PR TITLE
Fix tests missing dependencies

### DIFF
--- a/keep/build.gradle
+++ b/keep/build.gradle
@@ -41,8 +41,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.26'
 	
 	
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	
+        annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 }
 // --- 여기에 추가 ---
 sourceSets {
@@ -59,6 +60,6 @@ compileJava {
 	options.compilerArgs << '-parameters'
 }
 
-//tasks.named('test') {
-//	useJUnitPlatform()
-//}
+tasks.named('test') {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
## Summary
- enable JUnit with Spring Boot starter test deps
- activate test task configuration for JUnit Platform

## Testing
- `gradle test` *(fails: Plugin org.springframework.boot:3.4.4 not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859037e5a6c8327bc1940ba73ec11bf