### PR TITLE
Fix invite notification view

### DIFF
--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -36,10 +36,20 @@
                }
 
                 function sendNotification(recipientId, action) {
+                        let targetUrl = '/share?view=list';
+                        if (action === 'INVITE') {
+                                targetUrl = '/share?view=manage&type=invite';
+                        } else if (action === 'INVITE_REJECT') {
+                                targetUrl = '/share?view=invite';
+                        } else if (action === 'REQUEST_REJECT') {
+                                targetUrl = '/share?view=request';
+                        } else if (action === 'REQUEST') {
+                                targetUrl = '/share?view=manage&type=request';
+                        }
                         fetch('/api/notifications', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl: '/share?view=manage' })
+                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl })
                         });
                 }
                 async function handleInvite(id, canEdit, container, name) {

--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -1,10 +1,11 @@
 /*keep/src/main/resources/static/js/main/share/components/share-manage.js 에서 받은 요청및 받은 초대 버튼 클릭시 두번 클릭되는 현상이 발생하는데 안되도록 수정
 */
 (function() {
-	async function initShareManage() {
-		const toggleBtns = document.querySelectorAll('.list-toggle .toggle-btn');
-		const listContainer = document.querySelector('.list-container');
-		let currentType = 'request';
+        async function initShareManage() {
+                const toggleBtns = document.querySelectorAll('.list-toggle .toggle-btn');
+                const listContainer = document.querySelector('.list-container');
+                const params = new URLSearchParams(window.location.search);
+                let currentType = params.get('type') === 'invite' ? 'invite' : 'request';
 
 		function createDoneButton(text) {
 			const btn = document.createElement('button');
@@ -22,10 +23,16 @@
                 }
 
                 function sendNotification(recipientId, action) {
+                        let targetUrl = '/share?view=list';
+                        if (action === 'INVITE_REJECT') {
+                                targetUrl = '/share?view=invite';
+                        } else if (action === 'REQUEST_REJECT') {
+                                targetUrl = '/share?view=request';
+                        }
                         fetch('/api/notifications', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl: '/share?view=manage' })
+                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl })
                         });
                 }
 
@@ -168,8 +175,15 @@
                         }
                 });
 
-		// default view
-		load('request');
+                toggleBtns.forEach(btn => {
+                        if (btn.dataset.target === currentType) {
+                                btn.classList.add('active');
+                        } else {
+                                btn.classList.remove('active');
+                        }
+                });
+
+                load(currentType);
 	}
 
 	window.initShareManage = initShareManage;

--- a/keep/src/main/resources/static/js/main/share/components/share-request.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-request.js
@@ -40,10 +40,20 @@
                 }
 
                 function sendNotification(recipientId, action) {
+                        let targetUrl = '/share?view=list';
+                        if (action === 'REQUEST') {
+                                targetUrl = '/share?view=manage&type=request';
+                        } else if (action === 'INVITE_REJECT') {
+                                targetUrl = '/share?view=invite';
+                        } else if (action === 'REQUEST_REJECT') {
+                                targetUrl = '/share?view=request';
+                        } else if (action === 'INVITE') {
+                                targetUrl = '/share?view=manage&type=invite';
+                        }
                         fetch('/api/notifications', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl: '/share?view=manage' })
+                                body: JSON.stringify({ recipientId: recipientId, actionType: action, targetUrl })
                         });
                 }
 

--- a/keep/src/main/resources/static/js/main/share/share.js
+++ b/keep/src/main/resources/static/js/main/share/share.js
@@ -1,6 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-	const fragmentContainer = document.getElementById('fragment-container');
-	const viewBtns = document.querySelectorAll('.view-btn');
+        const fragmentContainer = document.getElementById('fragment-container');
+        const viewBtns = document.querySelectorAll('.view-btn');
+        const params = new URLSearchParams(window.location.search);
+        const allowedViews = ['list', 'request', 'invite', 'manage'];
+        let currentView = params.get('view');
+        if (!allowedViews.includes(currentView)) {
+                currentView = 'invite';
+        }
 
 	function loadView(view) {
 		fragmentContainer.style.opacity = 0;
@@ -15,23 +21,23 @@ document.addEventListener('DOMContentLoaded', () => {
 				document.getElementById('share-request-css').disabled = (view !== 'request');
 				document.getElementById('share-list-css').disabled = (view !== 'list');
 				document.getElementById('share-manage-css').disabled = (view !== 'manage');
-				if (view === 'invite') {
-					if (window.initShareInvite()) {
-						window.initShareInvite();
-					}
-				} else if (view === 'request') {
-					if (window.initShareRequest()) {
-						window.initShareRequest();
-					}
-				} else if (view === 'list') {
-					if (typeof window.initShareList === 'function') {
-						window.initShareList();
-					}
-				} else if (view === 'manage') {
-					if (window.initShareManage()) {
-						window.initShareManage();
-					}
-				}
+                                if (view === 'invite') {
+                                        if (typeof window.initShareInvite === 'function') {
+                                                window.initShareInvite();
+                                        }
+                                } else if (view === 'request') {
+                                        if (typeof window.initShareRequest === 'function') {
+                                                window.initShareRequest();
+                                        }
+                                } else if (view === 'list') {
+                                        if (typeof window.initShareList === 'function') {
+                                                window.initShareList();
+                                        }
+                                } else if (view === 'manage') {
+                                        if (typeof window.initShareManage === 'function') {
+                                                window.initShareManage();
+                                        }
+                                }
 				requestAnimationFrame(() => {
 					fragmentContainer.style.opacity = 1;
 				});
@@ -39,13 +45,21 @@ document.addEventListener('DOMContentLoaded', () => {
 			.catch(err => console.error(err));
 	}
 
-	viewBtns.forEach(btn => {
-		btn.addEventListener('click', () => {
-			const view = btn.dataset.view;
-			viewBtns.forEach(b => b.classList.toggle('active', b === btn));
-			loadView(view);
-		});
-	});
+        viewBtns.forEach(btn => {
+                btn.addEventListener('click', () => {
+                        const view = btn.dataset.view;
+                        viewBtns.forEach(b => b.classList.toggle('active', b === btn));
+                        loadView(view);
+                });
+        });
 
-	loadView('invite');
+        viewBtns.forEach(btn => {
+                if (btn.dataset.view === currentView) {
+                        btn.classList.add('active');
+                } else {
+                        btn.classList.remove('active');
+                }
+        });
+
+        loadView(currentView);
 });


### PR DESCRIPTION
## Summary
- support `view` query param in share.js to open the correct tab
- support `type` query param in share-manage.js to open the invite tab
- direct invite notifications to `/share?view=manage&type=invite`
- route request, invite reject notifications to the correct view

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a012a39f08327855387782b431d9b