### PR TITLE
Implement schedule list management

### DIFF
--- a/keep/src/main/java/com/keep/member/service/MemberService.java
+++ b/keep/src/main/java/com/keep/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.keep.member.service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.keep.schedulelist.service.ScheduleListService;
+
 import com.keep.member.dto.MemberDTO;
 import com.keep.member.entity.MemberEntity;
 import com.keep.member.repository.MemberRepository;
@@ -13,8 +15,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-	private final MemberRepository memberRepository;
-	private final PasswordEncoder passwordEncoder;
+        private final MemberRepository memberRepository;
+        private final PasswordEncoder passwordEncoder;
+        private final ScheduleListService scheduleListService;
 
 	// 회원가입
 	@Transactional
@@ -27,10 +30,11 @@ public class MemberService {
 				.hname(memberDTO.getHname()).build();
 
 		// 2. 저장 + 즉시 flush
-		MemberEntity saved = memberRepository.saveAndFlush(entity);
+                MemberEntity saved = memberRepository.saveAndFlush(entity);
 
-		// 3. 저장된 ID 반환
-		return saved.getId();
+                scheduleListService.createDefaultList(saved.getId());
+
+                return saved.getId();
 	}
 
 	// 이메일 중복검증

--- a/keep/src/main/java/com/keep/schedule/dto/ScheduleDTO.java
+++ b/keep/src/main/java/com/keep/schedule/dto/ScheduleDTO.java
@@ -21,9 +21,11 @@ import java.time.LocalTime;
 @Builder
 public class ScheduleDTO {
 
-	private Long userId;
+        private Long userId;
 
-	private Long schedulesId;
+        private Long schedulesId;
+
+        private Long scheduleListId;
 
 	private String fileUrl;
 

--- a/keep/src/main/java/com/keep/schedule/entity/ScheduleEntity.java
+++ b/keep/src/main/java/com/keep/schedule/entity/ScheduleEntity.java
@@ -18,8 +18,11 @@ public class ScheduleEntity {
 	@Column(name = "SCHEDULES_ID", nullable = false)
 	private Long schedulesId;
 
-	@Column(name = "USER_ID", nullable = false)
-	private Long userId;
+        @Column(name = "USER_ID", nullable = false)
+        private Long userId;
+
+        @Column(name = "SCHEDULE_LIST_ID")
+        private Long scheduleListId;
 
 	@Column(name = "TITLE", length = 30)
 	private String title;

--- a/keep/src/main/java/com/keep/schedule/mapper/ScheduleMapperImpl.java
+++ b/keep/src/main/java/com/keep/schedule/mapper/ScheduleMapperImpl.java
@@ -19,6 +19,7 @@ public class ScheduleMapperImpl implements ScheduleMapper {
         ScheduleEntity.ScheduleEntityBuilder builder = ScheduleEntity.builder();
         builder.schedulesId(dto.getSchedulesId());
         builder.userId(dto.getUserId());
+        builder.scheduleListId(dto.getScheduleListId());
         builder.title(dto.getTitle());
         builder.location(dto.getLocation());
         builder.description(dto.getDescription());
@@ -39,6 +40,7 @@ public class ScheduleMapperImpl implements ScheduleMapper {
         ScheduleDTO.ScheduleDTOBuilder builder = ScheduleDTO.builder();
         builder.userId(entity.getUserId());
         builder.schedulesId(entity.getSchedulesId());
+        builder.scheduleListId(entity.getScheduleListId());
         builder.title(entity.getTitle());
         builder.location(entity.getLocation());
         builder.description(entity.getDescription());

--- a/keep/src/main/java/com/keep/schedulelist/controller/ScheduleListController.java
+++ b/keep/src/main/java/com/keep/schedulelist/controller/ScheduleListController.java
@@ -1,0 +1,34 @@
+package com.keep.schedulelist.controller;
+
+import com.keep.schedulelist.dto.ScheduleListDTO;
+import com.keep.schedulelist.service.ScheduleListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/schedule-lists")
+@RequiredArgsConstructor
+public class ScheduleListController {
+    private final ScheduleListService service;
+
+    @GetMapping
+    public List<ScheduleListDTO> list(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+        return service.getLists(userId);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> create(Authentication authentication, @RequestBody ScheduleListDTO dto) {
+        Long userId = Long.valueOf(authentication.getName());
+        dto.setUserId(userId);
+        ScheduleListDTO saved = service.createList(dto);
+        URI location = URI.create("/api/schedule-lists/" + saved.getScheduleListId());
+        return ResponseEntity.created(location).body(Map.of("id", saved.getScheduleListId()));
+    }
+}

--- a/keep/src/main/java/com/keep/schedulelist/dto/ScheduleListDTO.java
+++ b/keep/src/main/java/com/keep/schedulelist/dto/ScheduleListDTO.java
@@ -1,0 +1,16 @@
+package com.keep.schedulelist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleListDTO {
+    private Long scheduleListId;
+    private String title;
+    private Long userId;
+}

--- a/keep/src/main/java/com/keep/schedulelist/entity/ScheduleListEntity.java
+++ b/keep/src/main/java/com/keep/schedulelist/entity/ScheduleListEntity.java
@@ -1,0 +1,51 @@
+package com.keep.schedulelist.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "SCHEDULE_LIST")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleListEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "schedule_list_seq_gen")
+    @SequenceGenerator(name = "schedule_list_seq_gen", sequenceName = "SCHEDULE_LIST_SEQ", allocationSize = 1)
+    @Column(name = "SCHEDULE_LIST_ID")
+    private Long scheduleListId;
+
+    @Column(name = "TITLE", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "USER_ID", nullable = false)
+    private Long userId;
+
+    @Column(name = "CREATED_BY")
+    private Long createdBy;
+
+    @Column(name = "CREATION_DATE")
+    private java.time.LocalDateTime creationDate;
+
+    @Column(name = "LAST_UPDATED_BY")
+    private Long lastUpdatedBy;
+
+    @Column(name = "LAST_UPDATE_DATE")
+    private java.time.LocalDateTime lastUpdateDate;
+
+    @Column(name = "LAST_UPDATE_LOGIN")
+    private Long lastUpdateLogin;
+
+    @PrePersist
+    protected void onCreate() {
+        java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        this.creationDate = now;
+        this.lastUpdateDate = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.lastUpdateDate = java.time.LocalDateTime.now();
+    }
+}

--- a/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapper.java
+++ b/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapper.java
@@ -1,0 +1,9 @@
+package com.keep.schedulelist.mapper;
+
+import com.keep.schedulelist.dto.ScheduleListDTO;
+import com.keep.schedulelist.entity.ScheduleListEntity;
+
+public interface ScheduleListMapper {
+    ScheduleListEntity toEntity(ScheduleListDTO dto);
+    ScheduleListDTO toDto(ScheduleListEntity entity);
+}

--- a/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapperImpl.java
+++ b/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapperImpl.java
@@ -1,0 +1,31 @@
+package com.keep.schedulelist.mapper;
+
+import com.keep.schedulelist.dto.ScheduleListDTO;
+import com.keep.schedulelist.entity.ScheduleListEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduleListMapperImpl implements ScheduleListMapper {
+    @Override
+    public ScheduleListEntity toEntity(ScheduleListDTO dto) {
+        if (dto == null) return null;
+        return ScheduleListEntity.builder()
+                .scheduleListId(dto.getScheduleListId())
+                .title(dto.getTitle())
+                .userId(dto.getUserId())
+                .createdBy(dto.getUserId())
+                .lastUpdatedBy(dto.getUserId())
+                .lastUpdateLogin(dto.getUserId())
+                .build();
+    }
+
+    @Override
+    public ScheduleListDTO toDto(ScheduleListEntity entity) {
+        if (entity == null) return null;
+        return ScheduleListDTO.builder()
+                .scheduleListId(entity.getScheduleListId())
+                .title(entity.getTitle())
+                .userId(entity.getUserId())
+                .build();
+    }
+}

--- a/keep/src/main/java/com/keep/schedulelist/repository/ScheduleListRepository.java
+++ b/keep/src/main/java/com/keep/schedulelist/repository/ScheduleListRepository.java
@@ -1,0 +1,10 @@
+package com.keep.schedulelist.repository;
+
+import com.keep.schedulelist.entity.ScheduleListEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScheduleListRepository extends JpaRepository<ScheduleListEntity, Long> {
+    List<ScheduleListEntity> findByUserId(Long userId);
+}

--- a/keep/src/main/java/com/keep/schedulelist/service/ScheduleListService.java
+++ b/keep/src/main/java/com/keep/schedulelist/service/ScheduleListService.java
@@ -1,0 +1,44 @@
+package com.keep.schedulelist.service;
+
+import com.keep.schedulelist.dto.ScheduleListDTO;
+import com.keep.schedulelist.entity.ScheduleListEntity;
+import com.keep.schedulelist.mapper.ScheduleListMapper;
+import com.keep.schedulelist.repository.ScheduleListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleListService {
+    private final ScheduleListRepository repository;
+    private final ScheduleListMapper mapper;
+
+    @Transactional
+    public Long createDefaultList(Long userId) {
+        ScheduleListEntity entity = ScheduleListEntity.builder()
+                .title("기본")
+                .userId(userId)
+                .createdBy(userId)
+                .lastUpdatedBy(userId)
+                .lastUpdateLogin(userId)
+                .build();
+        repository.save(entity);
+        return entity.getScheduleListId();
+    }
+
+    @Transactional
+    public ScheduleListDTO createList(ScheduleListDTO dto) {
+        ScheduleListEntity entity = repository.save(mapper.toEntity(dto));
+        return mapper.toDto(entity);
+    }
+
+    public List<ScheduleListDTO> getLists(Long userId) {
+        return repository.findByUserId(userId).stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/dashboard.css
+++ b/keep/src/main/resources/static/css/main/dashboard/dashboard.css
@@ -13,7 +13,18 @@
 }
 
 .dashboard-header-left {
-  flex: 1; /* 좌측 여유 공간 */
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.schedule-list-select {
+  padding: 4px 8px;
+}
+
+.list-add-btn {
+  padding: 4px 8px;
 }
 
 .dashboard-header-center {

--- a/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
@@ -4,9 +4,10 @@
 		const overlay = document.getElementById('schedule-modal-overlay');
 		const modal = document.getElementById('schedule-modal');
                 const cancel = document.getElementById('modal-cancel');
-                const deleteBtn = document.getElementById('modal-delete');
-		const colors = document.querySelectorAll('.cat-color');
-		const hiddenColorInput = document.getElementById('sched-color');
+               const deleteBtn = document.getElementById('modal-delete');
+               const colors = document.querySelectorAll('.cat-color');
+               const hiddenColorInput = document.getElementById('sched-color');
+               const listIdInput = document.getElementById('sched-list-id');
 		const form = document.getElementById('schedule-form');
 		const grid = document.querySelector('.schedule-grid');
 		const startHour = document.getElementById('sched-start-hour');
@@ -177,8 +178,12 @@
                         document.getElementById('sched-id').value = data.schedulesId;
 
                         // 삭제 버튼 표시
-                        const delBtn = document.getElementById('modal-delete');
-                        delBtn?.classList.remove('hidden');
+                       const delBtn = document.getElementById('modal-delete');
+                       delBtn?.classList.remove('hidden');
+
+                        if (listIdInput) {
+                                listIdInput.value = data.scheduleListId || '';
+                        }
 
 			// 카테고리 버튼 선택 상태 동기화
 			document.querySelectorAll('.cat-color').forEach(btn => {
@@ -199,6 +204,9 @@
                 if (delBtn) {
                        delBtn.classList.toggle('hidden', !document.getElementById('sched-id').value);
                 }
+                if (listIdInput && window.currentScheduleListId) {
+                        listIdInput.value = window.currentScheduleListId;
+                }
                 document.getElementById('schedule-modal-overlay').classList.remove('hidden');
                 document.getElementById('schedule-modal').classList.remove('hidden');
                 // 기본 색상 표시
@@ -212,6 +220,7 @@
                 document.getElementById('schedule-modal').classList.add('hidden');
                 document.getElementById('schedule-form').reset();
                 document.getElementById('sched-id').value = '';
+                if (listIdInput) listIdInput.value = '';
                 document.querySelectorAll('.cat-color').forEach(b => b.classList.remove('selected'));
                 const delBtn = document.getElementById('modal-delete');
                 delBtn?.classList.add('hidden');

--- a/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
@@ -1,0 +1,66 @@
+(function() {
+    async function loadLists() {
+        const select = document.getElementById('schedule-list-select');
+        if (!select) return;
+        try {
+            const res = await fetch('/api/schedule-lists');
+            if (!res.ok) throw new Error('network');
+            const data = await res.json();
+            select.innerHTML = '';
+            data.forEach(l => {
+                const opt = document.createElement('option');
+                opt.value = l.scheduleListId;
+                opt.textContent = l.title;
+                select.appendChild(opt);
+            });
+            if (data.length > 0) {
+                select.value = data[0].scheduleListId;
+                window.currentScheduleListId = data[0].scheduleListId;
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    function openModal() {
+        document.getElementById('schedule-list-modal-overlay').classList.remove('hidden');
+        document.getElementById('schedule-list-modal').classList.remove('hidden');
+        document.getElementById('schedule-list-title').value = '';
+    }
+
+    function closeModal() {
+        document.getElementById('schedule-list-modal-overlay').classList.add('hidden');
+        document.getElementById('schedule-list-modal').classList.add('hidden');
+    }
+
+    async function saveList() {
+        const title = document.getElementById('schedule-list-title').value.trim();
+        if (!title) return;
+        const res = await fetch('/api/schedule-lists', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title })
+        });
+        if (res.ok) {
+            await loadLists();
+            closeModal();
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const select = document.getElementById('schedule-list-select');
+        const addBtn = document.getElementById('schedule-list-add');
+        const saveBtn = document.getElementById('schedule-list-save');
+        const cancelBtn = document.getElementById('schedule-list-cancel');
+        const overlay = document.getElementById('schedule-list-modal-overlay');
+        select && select.addEventListener('change', () => {
+            window.currentScheduleListId = select.value;
+            if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
+        });
+        addBtn && addBtn.addEventListener('click', openModal);
+        saveBtn && saveBtn.addEventListener('click', saveList);
+        cancelBtn && cancelBtn.addEventListener('click', closeModal);
+        overlay && overlay.addEventListener('click', closeModal);
+        loadLists();
+    });
+})();

--- a/keep/src/main/resources/templates/main/dashboard/components/modal/schedule-list-modal.html
+++ b/keep/src/main/resources/templates/main/dashboard/components/modal/schedule-list-modal.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<div th:fragment="schedule-list-modal">
+  <div id="schedule-list-modal-overlay" class="modal-overlay hidden"></div>
+  <div id="schedule-list-modal" class="modal hidden">
+    <h3 class="modal-title">목록 추가</h3>
+    <div class="form-group">
+      <label for="schedule-list-title">제목</label>
+      <input type="text" id="schedule-list-title" />
+    </div>
+    <div class="modal-actions">
+      <button type="button" id="schedule-list-save" class="btn-primary">저장</button>
+      <button type="button" id="schedule-list-cancel" class="btn-secondary">취소</button>
+    </div>
+  </div>
+</div>
+</html>

--- a/keep/src/main/resources/templates/main/dashboard/components/modal/schedule-modal.html
+++ b/keep/src/main/resources/templates/main/dashboard/components/modal/schedule-modal.html
@@ -81,7 +81,8 @@
           취소
         </button>
       </div>
-      <input type="hidden" id ="sched-id" name ="schedulesId">
+      <input type="hidden" id="sched-list-id" name="scheduleListId">
+      <input type="hidden" id="sched-id" name="schedulesId">
     </form>
     
   </div>

--- a/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
+++ b/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
@@ -21,8 +21,11 @@
 <!--/* content */-->
 <th:block layout:fragment="content">
 	<div class="dashboard-header">
-		<!-- 좌측: 비워둔 영역 (추후 아이콘 등 추가 가능) -->
-		<div class="header-left"></div>
+                <!-- 좌측: 일정 목록 선택 -->
+                <div class="header-left">
+                        <select id="schedule-list-select" class="schedule-list-select"></select>
+                        <button type="button" id="schedule-list-add" class="list-add-btn">+</button>
+                </div>
 		<!-- 중앙: 날짜 내비게이션 -->
 		<div class="dashboard-header-center">
 			<button id="prev-date" class="date-nav">&lt;</button>
@@ -43,6 +46,7 @@
 	<!-- 	daily.html 등록 모달 -->	
 
              <div th:replace="~{main/dashboard/components/modal/schedule-modal :: schedule-modal}"></div>
+             <div th:replace="~{main/dashboard/components/modal/schedule-list-modal :: schedule-list-modal}"></div>
              <div th:replace="~{common/calendar-modal :: calendar-modal}"></div>
              <div th:replace="~{common/toast :: save-toast}"></div>
              <div th:replace="~{main/dashboard/components/modal/monthly-more-modal :: monthly-more-modal}"></div>
@@ -55,6 +59,7 @@
         <script th:src="@{/js/main/dashboard/components/dashboard-daily.js}"></script>
         <script th:src="@{/js/main/dashboard/components/dashboard-weekly.js}"></script>
         <script th:src="@{/js/main/dashboard/components/dashboard-monthly.js}"></script>
+        <script th:src="@{/js/main/dashboard/components/schedule-list.js}"></script>
         <script th:src="@{/js/main/dashboard/components/modal/schedule-modal.js}"></script>
         <script th:src="@{/js/main/common/toast.js}"></script>
         <script th:src="@{/js/main/dashboard/components/modal/monthly-more-modal.js}"></script>


### PR DESCRIPTION
## Summary
- introduce `ScheduleList` domain with DTO, entity, mapper, repository, service and controller
- add default schedule list creation on user signup
- attach schedule list ID to schedules
- enhance schedule modal to submit list id
- add schedule list selector UI and modal on dashboard
- add supporting CSS and JS

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a345add7c83279536bf2ce1382882