### PR TITLE
Add schedule list filtering

### DIFF
--- a/keep/src/main/java/com/keep/schedule/controller/ScheduleApiController.java
+++ b/keep/src/main/java/com/keep/schedule/controller/ScheduleApiController.java
@@ -55,10 +55,11 @@ public class ScheduleApiController {
 	 * 일간 일정 조회
 	 */
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<List<ScheduleDTO>> getSchedulesByDate(Authentication authentication,
-			@RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-		Long userId = Long.valueOf(authentication.getName());
-		List<ScheduleDTO> list = scheduleService.getEventsByDate(userId, date);
+        public ResponseEntity<List<ScheduleDTO>> getSchedulesByDate(Authentication authentication,
+                        @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+                        @RequestParam("scheduleListId") Long scheduleListId) {
+                Long userId = Long.valueOf(authentication.getName());
+                List<ScheduleDTO> list = scheduleService.getEventsByDate(userId, date, scheduleListId);
 
 		return ResponseEntity.ok(list);
 	}
@@ -99,13 +100,13 @@ public class ScheduleApiController {
 	 * 주간 일정 조회 GET /api/schedules?start=2025-05-25&end=2025-05-31
 	 */
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = { "start", "end" })
-	public ResponseEntity<List<ScheduleDTO>> getSchedulesByRange(Authentication authentication,
-			@RequestParam("start") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
-			@RequestParam("end") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end) {
+        public ResponseEntity<List<ScheduleDTO>> getSchedulesByRange(Authentication authentication,
+                        @RequestParam("start") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+                        @RequestParam("end") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
+                        @RequestParam("scheduleListId") Long scheduleListId) {
 
-		Long userId = Long.valueOf(authentication.getName());
-		// ScheduleService 에 getEventsByDateRange 메서드를 구현해야 합니다.
-		List<ScheduleDTO> list = scheduleService.getEventsByDateRange(userId, start, end);
+                Long userId = Long.valueOf(authentication.getName());
+                List<ScheduleDTO> list = scheduleService.getEventsByDateRange(userId, start, end, scheduleListId);
 		return ResponseEntity.ok(list);
 	}
 

--- a/keep/src/main/java/com/keep/schedule/repository/ScheduleRepository.java
+++ b/keep/src/main/java/com/keep/schedule/repository/ScheduleRepository.java
@@ -14,8 +14,9 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
    * startTs ≤ endOfDay  AND  endTs ≥ startOfDay
    * 조건을 만족하는 일정 전체를 시작 시각 순으로 조회
    */
-  List<ScheduleEntity> findAllByUserIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(
+  List<ScheduleEntity> findAllByUserIdAndScheduleListIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(
       Long userId,
+      Long scheduleListId,
       LocalDateTime endOfDay,
       LocalDateTime startOfDay
   );

--- a/keep/src/main/java/com/keep/schedule/service/ScheduleService.java
+++ b/keep/src/main/java/com/keep/schedule/service/ScheduleService.java
@@ -53,16 +53,18 @@ public class ScheduleService {
 	/**
 	 * userId 사용자의 주어진 날짜(date)에 속하는 일정 목록을 반환합니다. (daily 뷰에 사용)
 	 */
-	public List<ScheduleDTO> getEventsByDate(Long userId, LocalDate date) {
+        public List<ScheduleDTO> getEventsByDate(Long userId, LocalDate date, Long scheduleListId) {
 		// 그날 00:00부터 23:59:59까지
 		LocalDateTime startOfDay = date.atStartOfDay();
 		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
-		List<ScheduleEntity> entities = repository
-				.findAllByUserIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(userId, // 사용자
-						endOfDay, // startTs ≤ 이 값
-						startOfDay // endTs ≥ 이 값
-				);
+                List<ScheduleEntity> entities = repository
+                                .findAllByUserIdAndScheduleListIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(
+                                                userId, // 사용자
+                                                scheduleListId,
+                                                endOfDay, // startTs ≤ 이 값
+                                                startOfDay // endTs ≥ 이 값
+                                );
 		List<ScheduleDTO> t = entities.stream().map(entity -> {
 			ScheduleDTO dto = mapper.toDto(entity);
 
@@ -109,14 +111,17 @@ public class ScheduleService {
 		return mapper.toDto(entity);
 	}
 
-	public List<ScheduleDTO> getEventsByDateRange(Long userId, LocalDate start, LocalDate end) {
+        public List<ScheduleDTO> getEventsByDateRange(Long userId, LocalDate start, LocalDate end, Long scheduleListId) {
 		// start 는 00:00:00, end 는 23:59:59 로 설정
 		LocalDateTime startDateTime = start.atStartOfDay();
 		LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
 
-		List<ScheduleEntity> entitiy = repository
-				.findAllByUserIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(userId, endDateTime,
-						startDateTime);
+                List<ScheduleEntity> entitiy = repository
+                                .findAllByUserIdAndScheduleListIdAndStartTsLessThanEqualAndEndTsGreaterThanEqualOrderByStartTs(
+                                                userId,
+                                                scheduleListId,
+                                                endDateTime,
+                                                startDateTime);
 
 		return entitiy.stream().map(mapper::toDto).collect(Collectors.toList());
 	}

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
@@ -198,8 +198,8 @@
 		if (!dateInput) return;
 		const [year, month, day] = dateInput.split('-').map(n => +n);
 		let events = [];
-		try {
-			const res = await fetch(`/api/schedules?date=${dateInput}`);
+                try {
+                        const res = await fetch(`/api/schedules?date=${dateInput}&scheduleListId=${window.currentScheduleListId}`);
 			if (res.ok) events = await res.json();
 		} catch (err) {
 			console.error('일정 로드 실패', err);

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
@@ -21,9 +21,9 @@
 		const weekStart = new Date(year, sMM - 1, sDD);
 		const weekEnd = new Date(year, eMM - 1, eDD);
 		// 2) API 호출
-		const res = await fetch(
-			`/api/schedules?start=${formatYMD(weekStart)}&end=${formatYMD(weekEnd)}`
-		);
+                const res = await fetch(
+                        `/api/schedules?start=${formatYMD(weekStart)}&end=${formatYMD(weekEnd)}&scheduleListId=${window.currentScheduleListId}`
+                );
 		const schedules = await res.json(); // [{ schedulesId, title, startTs, endTs, category, ... }, ...]
 
 		const ALL_DAY_MS = 24 * 60 * 60 * 1000;

--- a/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
@@ -16,6 +16,7 @@
             if (data.length > 0) {
                 select.value = data[0].scheduleListId;
                 window.currentScheduleListId = data[0].scheduleListId;
+                if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
             }
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
## Summary
- filter schedules by schedule_list_id in repository and service
- accept scheduleListId when querying schedules in the controller
- send scheduleListId from dashboard JS fetch calls
- refresh schedules once lists are loaded

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a4a03fe088327bc7d151ed31a32d9