### PR TITLE
Maintain current schedule list id

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
@@ -204,8 +204,13 @@
                 if (delBtn) {
                        delBtn.classList.toggle('hidden', !document.getElementById('sched-id').value);
                 }
-                if (listIdInput && window.currentScheduleListId) {
-                        listIdInput.value = window.currentScheduleListId;
+                if (listIdInput) {
+                        const hiddenInput = document.getElementById('current-schedule-list-id');
+                        if (hiddenInput && hiddenInput.value) {
+                                listIdInput.value = hiddenInput.value;
+                        } else if (window.currentScheduleListId) {
+                                listIdInput.value = window.currentScheduleListId;
+                        }
                 }
                 document.getElementById('schedule-modal-overlay').classList.remove('hidden');
                 document.getElementById('schedule-modal').classList.remove('hidden');

--- a/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
@@ -16,6 +16,8 @@
             if (data.length > 0) {
                 select.value = data[0].scheduleListId;
                 window.currentScheduleListId = data[0].scheduleListId;
+                const hiddenInput = document.getElementById('current-schedule-list-id');
+                if (hiddenInput) hiddenInput.value = data[0].scheduleListId;
                 if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
             }
         } catch (e) {
@@ -56,6 +58,8 @@
         const overlay = document.getElementById('schedule-list-modal-overlay');
         select && select.addEventListener('change', () => {
             window.currentScheduleListId = select.value;
+            const hiddenInput = document.getElementById('current-schedule-list-id');
+            if (hiddenInput) hiddenInput.value = select.value;
             if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
         });
         addBtn && addBtn.addEventListener('click', openModal);

--- a/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
+++ b/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
@@ -25,6 +25,7 @@
                 <div class="header-left">
                         <select id="schedule-list-select" class="schedule-list-select"></select>
                         <button type="button" id="schedule-list-add" class="list-add-btn">+</button>
+                        <input type="hidden" id="current-schedule-list-id" />
                 </div>
 		<!-- 중앙: 날짜 내비게이션 -->
 		<div class="dashboard-header-center">


### PR DESCRIPTION
## Summary
- persist the selected schedule list ID in a hidden field in `dashboard-main.html`
- keep that hidden value updated in `schedule-list.js`
- use the hidden value when opening `schedule-modal`

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a4dae7b688327a501d377aef5aae2