### PR TITLE
Fix schedule modal variable scope

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
@@ -1,4 +1,6 @@
 (function() {
+        // 외부 함수에서 접근 가능한 모달 내부 요소들
+        let listIdInput;
 
 	function initScheduleModal() {
 		const overlay = document.getElementById('schedule-modal-overlay');
@@ -7,7 +9,7 @@
                const deleteBtn = document.getElementById('modal-delete');
                const colors = document.querySelectorAll('.cat-color');
                const hiddenColorInput = document.getElementById('sched-color');
-               const listIdInput = document.getElementById('sched-list-id');
+               listIdInput = document.getElementById('sched-list-id');
 		const form = document.getElementById('schedule-form');
 		const grid = document.querySelector('.schedule-grid');
 		const startHour = document.getElementById('sched-start-hour');


### PR DESCRIPTION
## Summary
- fix `listIdInput` reference error by storing the element in a shared variable

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a5039a45c832791371cc80cc9e88f