### PR TITLE
Fix monthly calendar API parameters

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
@@ -23,7 +23,8 @@
 		const end = new Date(last);
 		end.setDate(end.getDate() + (6 - end.getDay()));
 
-		const res = await fetch(`/api/schedules?start=${formatYMD(start)}&end=${formatYMD(end)}`);
+                const listId = window.currentScheduleListId || '';
+                const res = await fetch(`/api/schedules?start=${formatYMD(start)}&end=${formatYMD(end)}&scheduleListId=${listId}`);
 		const events = res.ok ? await res.json() : [];
 
 		renderCalendar(first, events);


### PR DESCRIPTION
## Summary
- include schedule list ID when fetching monthly schedules

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a563369d083278dff33187d1342cf