### PR TITLE
Fix header and modal styling

### DIFF
--- a/keep/src/main/resources/static/css/main/dashboard/modal/schedule-modal.css
+++ b/keep/src/main/resources/static/css/main/dashboard/modal/schedule-modal.css
@@ -76,6 +76,12 @@
   box-sizing: border-box;
 }
 
+/* schedule-list-modal inputs should use full width */
+#schedule-list-modal .form-group input[type="text"],
+#schedule-list-modal .form-group select {
+  width: 100%;
+}
+
 /* datetime 그룹: label 아래에 inputs 표시 */
 .datetime-group {
   display: block;

--- a/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
+++ b/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
@@ -22,10 +22,10 @@
 <th:block layout:fragment="content">
 	<div class="dashboard-header">
                 <!-- 좌측: 일정 목록 선택 -->
-                <div class="header-left">
-                목록 : 
+                <div class="dashboard-header-left">
+                목록 :
                         <select id="schedule-list-select" class="schedule-list-select"></select>
-                        <button type="button" id="schedule-list-add" class="list-add-btn">+</button>
+                        <button type="button" id="schedule-list-add" class="list-add-btn">추가</button>
                         <button type="button" id="schedule-list-edit" class="list-edit-btn">편집</button>
                         <input type="hidden" id="current-schedule-list-id" />
                 </div>


### PR DESCRIPTION
## Summary
- ensure dashboard header-left styling matches others
- unify list buttons with text
- adjust schedule-list modal inputs to full width

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b3861399083278e9f6db68ac399b1