### PR TITLE
Add my schedule management view

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-myschedule.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-myschedule.css
@@ -1,0 +1,48 @@
+.mylist-header {
+  margin-bottom: 10px;
+}
+
+#mylist-container .mylist-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+#mylist-container .mylist-item:last-child {
+  border-bottom: none;
+}
+
+.mylist-item .edit-btn {
+  margin-right: 8px;
+}
+
+.mylist-item .title-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 6px 4px;
+}
+
+.mylist-item .title-input.editable {
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+.mylist-share {
+  white-space: nowrap;
+}
+
+.mylist-share .share-btn {
+  margin-left: 4px;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.mylist-share .share-btn.active {
+  background-color: #4f46e5;
+  color: #fff;
+}

--- a/keep/src/main/resources/static/js/main/share/components/share-myschedule.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-myschedule.js
@@ -1,0 +1,142 @@
+(function() {
+    async function updateList(id, body) {
+        await fetch(`/api/schedule-lists/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+    }
+
+    async function loadLists() {
+        const container = document.getElementById('mylist-container');
+        container.innerHTML = '';
+        try {
+            const res = await fetch('/api/schedule-lists');
+            const data = await res.json();
+            if (data.length === 0) {
+                container.innerHTML = '<div class="placeholder">목록이 없습니다.</div>';
+                return;
+            }
+            data.forEach(l => {
+                const div = document.createElement('div');
+                div.className = 'mylist-item';
+
+                const left = document.createElement('div');
+                const editBtn = document.createElement('button');
+                editBtn.className = 'edit-btn';
+                editBtn.textContent = '편집';
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.value = l.title;
+                input.className = 'title-input';
+                input.disabled = true;
+                left.appendChild(editBtn);
+                left.appendChild(input);
+
+                const share = document.createElement('div');
+                share.className = 'mylist-share';
+                share.textContent = '공유여부 : ';
+                const yBtn = document.createElement('button');
+                yBtn.className = 'share-btn';
+                yBtn.textContent = 'Y';
+                const nBtn = document.createElement('button');
+                nBtn.className = 'share-btn';
+                nBtn.textContent = 'N';
+                share.appendChild(yBtn);
+                share.appendChild(nBtn);
+
+                function refreshShare() {
+                    yBtn.classList.toggle('active', l.isShareable === 'Y');
+                    nBtn.classList.toggle('active', l.isShareable === 'N');
+                }
+                refreshShare();
+
+                yBtn.addEventListener('click', async () => {
+                    if (l.isShareable === 'Y') return;
+                    await updateList(l.scheduleListId, { title: input.value, isShareable: 'Y' });
+                    l.isShareable = 'Y';
+                    refreshShare();
+                    window.saveToast?.showMessage('해당 일정을 공유할수 있습니다.');
+                });
+                nBtn.addEventListener('click', async () => {
+                    if (l.isShareable === 'N') return;
+                    await updateList(l.scheduleListId, { title: input.value, isShareable: 'N' });
+                    l.isShareable = 'N';
+                    refreshShare();
+                    window.saveToast?.showMessage('공유가 취소 되었습니다.');
+                });
+
+                editBtn.addEventListener('click', async () => {
+                    if (editBtn.textContent === '편집') {
+                        input.disabled = false;
+                        input.classList.add('editable');
+                        input.focus();
+                        editBtn.textContent = '저장';
+                    } else {
+                        const newTitle = input.value.trim();
+                        if (!newTitle) {
+                            input.value = l.title;
+                        } else if (newTitle !== l.title) {
+                            await updateList(l.scheduleListId, { title: newTitle, isShareable: l.isShareable });
+                            l.title = newTitle;
+                            window.saveToast?.showMessage('저장되었습니다');
+                        }
+                        input.disabled = true;
+                        input.classList.remove('editable');
+                        editBtn.textContent = '편집';
+                    }
+                });
+
+                div.appendChild(left);
+                div.appendChild(share);
+                container.appendChild(div);
+            });
+        } catch (e) {
+            console.error(e);
+            container.innerHTML = '<div class="placeholder">불러오지 못했습니다.</div>';
+        }
+    }
+
+    function initAdd() {
+        const overlay = document.getElementById('schedule-list-modal-overlay');
+        const modal = document.getElementById('schedule-list-modal');
+        const titleInput = document.getElementById('schedule-list-title');
+        const shareSel = document.getElementById('schedule-list-share');
+        const saveBtn = document.getElementById('schedule-list-save');
+        const cancelBtn = document.getElementById('schedule-list-cancel');
+        const addBtn = document.getElementById('mylist-add');
+
+        function openModal() {
+            titleInput.value = '';
+            shareSel.value = 'Y';
+            overlay.classList.remove('hidden');
+            modal.classList.remove('hidden');
+        }
+        function closeModal() {
+            overlay.classList.add('hidden');
+            modal.classList.add('hidden');
+        }
+        async function save() {
+            const title = titleInput.value.trim();
+            if (!title) return;
+            await fetch('/api/schedule-lists', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title, isShareable: shareSel.value })
+            });
+            closeModal();
+            loadLists();
+            window.saveToast?.showMessage('저장되었습니다');
+        }
+
+        addBtn?.addEventListener('click', openModal);
+        saveBtn?.addEventListener('click', save);
+        cancelBtn?.addEventListener('click', closeModal);
+        overlay?.addEventListener('click', closeModal);
+    }
+
+    window.initShareMyList = function() {
+        loadLists();
+        initAdd();
+    };
+})();

--- a/keep/src/main/resources/static/js/main/share/share.js
+++ b/keep/src/main/resources/static/js/main/share/share.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const fragmentContainer = document.getElementById('fragment-container');
         const viewBtns = document.querySelectorAll('.view-btn');
         const params = new URLSearchParams(window.location.search);
-        const allowedViews = ['list', 'request', 'invite', 'manage'];
+        const allowedViews = ['list', 'request', 'invite', 'manage', 'mylist'];
         let currentView = params.get('view');
         if (!allowedViews.includes(currentView)) {
                 currentView = 'invite';
@@ -20,7 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				document.getElementById('share-invite-css').disabled = (view !== 'invite');
 				document.getElementById('share-request-css').disabled = (view !== 'request');
 				document.getElementById('share-list-css').disabled = (view !== 'list');
-				document.getElementById('share-manage-css').disabled = (view !== 'manage');
+                                document.getElementById('share-manage-css').disabled = (view !== 'manage');
+                                document.getElementById('share-mylist-css').disabled = (view !== 'mylist');
                                 if (view === 'invite') {
                                         if (typeof window.initShareInvite === 'function') {
                                                 window.initShareInvite();
@@ -36,6 +37,10 @@ document.addEventListener('DOMContentLoaded', () => {
                                 } else if (view === 'manage') {
                                         if (typeof window.initShareManage === 'function') {
                                                 window.initShareManage();
+                                        }
+                                } else if (view === 'mylist') {
+                                        if (typeof window.initShareMyList === 'function') {
+                                                window.initShareMyList();
                                         }
                                 }
 				requestAnimationFrame(() => {

--- a/keep/src/main/resources/templates/main/share/components/share-myschedule.html
+++ b/keep/src/main/resources/templates/main/share/components/share-myschedule.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<div th:fragment="content">
+    <div class="mylist-header">
+        <button type="button" id="mylist-add" class="list-add-btn">추가하기</button>
+    </div>
+    <div id="mylist-container" class="list-container"></div>
+    <div th:replace="~{main/dashboard/components/modal/schedule-list-modal :: schedule-list-modal}"></div>
+</div>
+</html>

--- a/keep/src/main/resources/templates/main/share/share-main.html
+++ b/keep/src/main/resources/templates/main/share/share-main.html
@@ -9,9 +9,10 @@
 <th:block layout:fragment="add-css">
         <link rel="stylesheet" th:href="@{/css/main/share/share.css}" />
         <link id="share-invite-css" rel="stylesheet" th:href="@{/css/main/share/components/share-invite.css}" />
-        <link id="share-list-css"rel="stylesheet" th:href="@{/css/main/share/components/share-list.css}" />
-        <link id="share-manage-css"rel="stylesheet" th:href="@{/css/main/share/components/share-manage.css}" />
-        <link id="share-request-css"rel="stylesheet" th:href="@{/css/main/share/components/share-request.css}" />
+        <link id="share-list-css" rel="stylesheet" th:href="@{/css/main/share/components/share-list.css}" />
+        <link id="share-manage-css" rel="stylesheet" th:href="@{/css/main/share/components/share-manage.css}" />
+        <link id="share-request-css" rel="stylesheet" th:href="@{/css/main/share/components/share-request.css}" />
+        <link id="share-mylist-css" rel="stylesheet" th:href="@{/css/main/share/components/share-myschedule.css}" />
         <!-- Toast style reuse -->
         <link rel="stylesheet" th:href="@{/css/main/dashboard/modal/save-toast.css}" />
 </th:block>
@@ -28,6 +29,7 @@
                         <button class="view-btn" data-view="request">요청</button>
                         <button class="view-btn active" data-view="invite">초대</button>
                         <button class="view-btn" data-view="manage">관리</button>
+                        <button class="view-btn" data-view="mylist">나의 일정</button>
                 </div>
         </div>
         <div id="fragment-container" data-id ="${session.memberId}"></div>
@@ -41,6 +43,7 @@
         <script th:src="@{/js/main/share/components/share-list.js}"></script>
         <script th:src="@{/js/main/share/components/share-request.js}"></script>
         <script th:src="@{/js/main/share/components/share-manage.js}"></script>
+        <script th:src="@{/js/main/share/components/share-myschedule.js}"></script>
         <script th:src="@{/js/main/common/toast.js}"></script>
 </th:block>
 


### PR DESCRIPTION
## Summary
- add `나의 일정` button to share page and load schedule list view
- create `share-myschedule.html` fragment for schedule list management
- support editing and share toggling with `share-myschedule.js`
- style new view with `share-myschedule.css`
- update share.js to handle new view

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b47a708f08327b5c390a54512d250