### PR TITLE
Add schedule list filter to share invite

### DIFF
--- a/keep/src/main/java/com/keep/share/controller/InvitationController.java
+++ b/keep/src/main/java/com/keep/share/controller/InvitationController.java
@@ -23,9 +23,10 @@ public class InvitationController {
     @Operation(summary = "Search users to invite")
     @GetMapping("/users")
     public List<ScheduleShareUserDTO> listAvailableInviteUsers(@RequestParam("name") String name,
+                                                               @RequestParam("scheduleListId") Long scheduleListId,
                                                                Authentication authentication) {
         Long sharerId = Long.valueOf(authentication.getName());
-        return shareService.searchAvailableForInvite(sharerId, name);
+        return shareService.searchAvailableForInvite(sharerId, name, scheduleListId);
     }
 
     @Operation(summary = "Send invitation")
@@ -35,7 +36,7 @@ public class InvitationController {
                                                @RequestBody RequestPermissionDTO dto) {
         Long sharerId = Long.valueOf(authentication.getName());
         String canEdit = dto.getCanEdit() == null ? "N" : dto.getCanEdit();
-        shareService.invite(sharerId, dto.getReceiverId(), canEdit);
+        shareService.invite(sharerId, dto.getReceiverId(), canEdit, dto.getScheduleListId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/keep/src/main/java/com/keep/share/dto/RequestPermissionDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/RequestPermissionDTO.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class RequestPermissionDTO {
+    private Long scheduleListId;
     private Long scheduleShareId;
     private Long scheduleId;
     private Long sharerId;

--- a/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
+++ b/keep/src/main/java/com/keep/share/entity/ScheduleShareEntity.java
@@ -34,8 +34,11 @@ public class ScheduleShareEntity {
 	@Column(name = "ACCEPT_YN")
 	private String acceptYn;
 
-	@Column(name = "ACTION_TYPE")
-	private String actionType;
+        @Column(name = "ACTION_TYPE")
+        private String actionType;
+
+        @Column(name = "SCHEDULE_LIST_ID")
+        private Long scheduleListId;
 
 	@Lob
 	@Column(name = "MESSAGE")

--- a/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
+++ b/keep/src/main/java/com/keep/share/mapper/ShareMapperImpl.java
@@ -13,6 +13,7 @@ public class ShareMapperImpl implements ShareMapper {
             return null;
         }
         return RequestPermissionDTO.builder()
+                .scheduleListId(entity.getScheduleListId())
                 .scheduleShareId(entity.getId())
                 .sharerId(entity.getSharerId())
                 .receiverId(entity.getReceiverId())
@@ -32,6 +33,7 @@ public class ShareMapperImpl implements ShareMapper {
                 .id(dto.getScheduleShareId())
                 .sharerId(dto.getSharerId())
                 .receiverId(dto.getReceiverId())
+                .scheduleListId(dto.getScheduleListId())
                 .canEdit(dto.getCanEdit())
                 .acceptYn(dto.getAcceptYn())
                 .message(dto.getMessage())

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -24,20 +24,24 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 			                         case when r.id is not null then true else false end
 			                     )
 			                     from MemberEntity m
-			                     left join ScheduleShareEntity s
-			                       on s.sharerId = :sharerId
-			                      and s.receiverId = m.id
+                                             left join ScheduleShareEntity s
+                                               on s.sharerId = :sharerId
+                                              and s.receiverId = m.id
+                                              and s.scheduleListId = :scheduleListId
 			                      
-			                     left join ScheduleShareEntity r
-			                       on r.sharerId = :sharerId
-			                      and r.receiverId = m.id
-			                      and r.actionType = 'R'
-			                      and r.acceptYn = 'N'
+                                             left join ScheduleShareEntity r
+                                               on r.sharerId = :sharerId
+                                              and r.receiverId = m.id
+                                              and r.scheduleListId = :scheduleListId
+                                              and r.actionType = 'R'
+                                              and r.acceptYn = 'N'
 			                     where lower(m.hname) like lower(concat('%', :name, '%'))
 			                      and m.id <> :sharerId
 			                     order by m.hname
 			""")
-	List<ScheduleShareUserDTO> searchAvailableForInvite(@Param("sharerId") Long sharerId, @Param("name") String name);
+        List<ScheduleShareUserDTO> searchAvailableForInvite(@Param("sharerId") Long sharerId,
+                                                            @Param("name") String name,
+                                                            @Param("scheduleListId") Long scheduleListId);
 
 	@Query("""
 			                     select new com.keep.share.dto.ScheduleShareUserDTO(

--- a/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
+++ b/keep/src/main/java/com/keep/share/service/ScheduleShareService.java
@@ -23,12 +23,13 @@ public class ScheduleShareService {
 	private final ScheduleShareRepository repository;
 	private final ShareMapper mapper;
 
-	public void invite(Long sharerId, Long receiverId, String canEdit) {
-		ScheduleShareEntity entity = ScheduleShareEntity.builder().sharerId(sharerId).receiverId(receiverId)
-				.canEdit(canEdit).acceptYn("N").actionType("I").createdBy(sharerId).lastUpdatedBy(sharerId)
-				.lastUpdateLogin(sharerId).build();
-		repository.save(entity);
-	}
+        public void invite(Long sharerId, Long receiverId, String canEdit, Long scheduleListId) {
+                ScheduleShareEntity entity = ScheduleShareEntity.builder().sharerId(sharerId).receiverId(receiverId)
+                                .scheduleListId(scheduleListId)
+                                .canEdit(canEdit).acceptYn("N").actionType("I").createdBy(sharerId).lastUpdatedBy(sharerId)
+                                .lastUpdateLogin(sharerId).build();
+                repository.save(entity);
+        }
 
 	public void request(Long sharerId, Long receiverId, String message) {
 		ScheduleShareEntity entity = ScheduleShareEntity.builder().sharerId(sharerId).receiverId(receiverId).canEdit("N")
@@ -37,9 +38,9 @@ public class ScheduleShareService {
 		repository.save(entity);
 	}
 
-	public List<ScheduleShareUserDTO> searchAvailableForInvite(Long sharerId, String name) {
-		return repository.searchAvailableForInvite(sharerId, name);
-	}
+        public List<ScheduleShareUserDTO> searchAvailableForInvite(Long sharerId, String name, Long scheduleListId) {
+                return repository.searchAvailableForInvite(sharerId, name, scheduleListId);
+        }
 
 	public List<ScheduleShareUserDTO> searchAvailableForRequest(Long sharerId, String name) {
 		return repository.searchAvailableForRequest(sharerId, name);

--- a/keep/src/main/resources/templates/main/share/components/share-invite.html
+++ b/keep/src/main/resources/templates/main/share/components/share-invite.html
@@ -3,6 +3,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <div th:fragment="content">
     <div class="search-bar">
+        <select id="schedule-list-select"></select>
         <input type="text" id="invite-search-input" placeholder="이름 검색" />
         <button type="button" id="invite-search-btn">검색</button>
     </div>


### PR DESCRIPTION
## Summary
- include `SCHEDULE_LIST_ID` column in `ScheduleShareEntity`
- extend `RequestPermissionDTO` and mapping for schedule list
- pass schedule list id to invite APIs and repository query
- add dropdown for shareable schedules and disable search if none
- update frontend fetches to send `scheduleListId`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b811108988327bde54c446778962b