### PR TITLE
Hide inputs when no shareable schedules

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -62,3 +62,7 @@
 #invite-list .list-item:last-child {
   border-bottom: 1px solid #ddd;
 }
+
+#go-mylist {
+  margin-top: 6px;
+}

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -24,7 +24,7 @@
                function renderNoShareable() {
                        ensureList();
                        list.style.minHeight = '';
-                       list.innerHTML = `<div class="placeholder">공유가능한 일정이 없습니다.<br/><button id="go-mylist" class="invite-btn">나의 일정으로 바로가기</button></div>`;
+                       list.innerHTML = `<div class="placeholder">공유가능한 일정이 없습니다.<br/><button id="go-mylist" class="invite-btn go-mylist">나의 일정으로 바로가기</button></div>`;
                        document.getElementById('go-mylist')?.addEventListener('click', () => {
                                window.location.href = '/share?view=mylist';
                        });
@@ -36,6 +36,8 @@
                                 const shareable = data.filter(l => l.isShareable === 'Y');
                                 if (shareable.length === 0) {
                                         btn.disabled = true;
+                                        listSelect.style.display = 'none';
+                                        input.style.display = 'none';
                                         renderNoShareable();
                                 } else {
                                         listSelect.innerHTML = shareable.map(l => `<option value="${l.scheduleListId}">${l.title}</option>`).join('');


### PR DESCRIPTION
## Summary
- adjust invite flow to hide schedule list and search input when there are no shareable schedules
- add margin for the `go-mylist` button

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b856320548327ae06a65fd1fe2c77