### PR TITLE
Fix invite view when no shareable schedules

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-invite.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-invite.css
@@ -13,6 +13,7 @@
   /* Match container height to occupy remaining space */
   min-height: calc(100vh - 240px);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 }

--- a/keep/src/main/resources/static/js/main/share/components/share-invite.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-invite.js
@@ -1,9 +1,10 @@
 (function() {
 	//keep/src/main/resources/static/js/main/share/components/share-invite.js
 	function initShareInvite() {
-                const input = document.getElementById('invite-search-input');
-                const btn = document.getElementById('invite-search-btn');
-                const listSelect = document.getElementById('schedule-list-select');
+               const input = document.getElementById('invite-search-input');
+               const btn = document.getElementById('invite-search-btn');
+               const listSelect = document.getElementById('schedule-list-select');
+               const searchBar = input.closest('.search-bar');
                 let list = document.getElementById('invite-list');
 
 		function ensureList() {
@@ -24,7 +25,7 @@
                function renderNoShareable() {
                        ensureList();
                        list.style.minHeight = '';
-                       list.innerHTML = `<div class="placeholder">공유가능한 일정이 없습니다.<br/><button id="go-mylist" class="invite-btn go-mylist">나의 일정으로 바로가기</button></div>`;
+                       list.innerHTML = `<div class="placeholder"><span>공유가능한 일정이 없습니다.</span><button id="go-mylist" class="invite-btn go-mylist">나의 일정으로 바로가기</button></div>`;
                        document.getElementById('go-mylist')?.addEventListener('click', () => {
                                window.location.href = '/share?view=mylist';
                        });
@@ -38,6 +39,7 @@
                                         btn.disabled = true;
                                         listSelect.style.display = 'none';
                                         input.style.display = 'none';
+                                        if (searchBar) searchBar.style.display = 'none';
                                         renderNoShareable();
                                 } else {
                                         listSelect.innerHTML = shareable.map(l => `<option value="${l.scheduleListId}">${l.title}</option>`).join('');


### PR DESCRIPTION
## Summary
- hide the search bar when there are no shareable schedules
- adjust placeholder layout so the `나의 일정으로 바로가기` button appears below the message

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b869b28008327a5fa5e30d512c8b9