### PR TITLE
Refactor schedule request search

### DIFF
--- a/keep/src/main/java/com/keep/schedulelist/repository/ScheduleListRepository.java
+++ b/keep/src/main/java/com/keep/schedulelist/repository/ScheduleListRepository.java
@@ -9,4 +9,6 @@ public interface ScheduleListRepository extends JpaRepository<ScheduleListEntity
     List<ScheduleListEntity> findByUserId(Long userId);
 
     List<ScheduleListEntity> findByUserIdAndIsShareable(Long userId, String isShareable);
+
+    List<ScheduleListEntity> findByUserIdInAndIsShareable(List<Long> userIds, String isShareable);
 }

--- a/keep/src/main/java/com/keep/share/controller/RequestController.java
+++ b/keep/src/main/java/com/keep/share/controller/RequestController.java
@@ -33,10 +33,10 @@ public class RequestController {
 
         @GetMapping("/users-with-lists")
         @Operation(summary = "Search users with shareable schedules")
-        public List<RequestUserDTO> listAvailableRequestUsersWithLists(@RequestParam("name") String name,
+        public List<RequestUserDTO> listRequestableUsersWithSchedules(@RequestParam("name") String name,
                         Authentication authentication) {
                 Long receiverId = Long.valueOf(authentication.getName());
-                return shareService.searchAvailableForRequestWithSchedules(receiverId, name);
+                return shareService.searchRequestableUsersWithSchedules(receiverId, name);
         }
 
 	// —————————————————————————————————————————————————————————

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -157,9 +157,9 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 	@Query("UPDATE ScheduleShareEntity s SET s.acceptYn = 'Y' WHERE s.id = :id")
 	int markAcceptedById(@Param("id") Long id);
 
-	@Modifying
-	@Query("DELETE FROM ScheduleShareEntity s WHERE s.id = :id")
-	int deleteShareById(@Param("id") Long id);
+        @Modifying
+        @Query("DELETE FROM ScheduleShareEntity s WHERE s.id = :id")
+        int deleteShareById(@Param("id") Long id);
 
 	java.util.Optional<ScheduleShareEntity> findFirstBySharerIdAndReceiverIdAndActionTypeAndAcceptYn(Long sharerId,
 			Long receiverId, String actionType, String acceptYn);
@@ -172,4 +172,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         java.util.Optional<ScheduleShareEntity> findFirstBySharerIdAndReceiverIdAndScheduleListId(Long sharerId,
                         Long receiverId, Long scheduleListId);
+
+        List<ScheduleShareEntity> findBySharerIdInAndReceiverIdAndScheduleListIdIn(List<Long> sharerIds,
+                        Long receiverId, List<Long> scheduleListIds);
 }


### PR DESCRIPTION
## Summary
- add batch query methods for schedule list and share repositories
- optimize requestable user search to avoid N+1 queries
- rename API method for clarity and improve null safety

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assemble` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ba528b36c83278fd3cc901e6e9fb7