### PR TITLE
Add schedule title to invitations

### DIFF
--- a/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
+++ b/keep/src/main/java/com/keep/share/dto/ScheduleShareUserDTO.java
@@ -30,6 +30,9 @@ public class ScheduleShareUserDTO {
     /** 회원 이름 (hname) */
     String hname;
 
+    /** 스케줄 목록 제목 */
+    String title;
+
     /** 초대 가능 여부 */
     Boolean invitable;
 

--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -12,17 +12,18 @@ import java.util.List;
 public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEntity, Long> {
 
 	@Query("""
-			                     select new com.keep.share.dto.ScheduleShareUserDTO(
-			                         r.id,
-			                         s.sharerId,
-			                         s.receiverId,
-			                         s.canEdit,
-			                         s.acceptYn,
-			                         m.id,
-			                         m.hname,
-			                         case when s.id is null then true else false end,
-			                         case when r.id is not null then true else false end
-			                     )
+                                             select new com.keep.share.dto.ScheduleShareUserDTO(
+                                                 r.id,
+                                                 s.sharerId,
+                                                 s.receiverId,
+                                                 s.canEdit,
+                                                 s.acceptYn,
+                                                 m.id,
+                                                 m.hname,
+                                                 null,
+                                                 case when s.id is null then true else false end,
+                                                 case when r.id is not null then true else false end
+                                             )
 			                     from MemberEntity m
                                              left join ScheduleShareEntity s
                                                on s.sharerId = :sharerId
@@ -49,11 +50,12 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 			                         s.sharerId,
 			                         s.receiverId,
 			                         s.canEdit,
-			                         r.acceptYn,
-			                         m.id,
-			                         m.hname,
-			                         case when s.id is null then true else false end,
-			                         case when r.id is not null then true else false end
+                                             r.acceptYn,
+                                             m.id,
+                                             m.hname,
+                                             null,
+                                             case when s.id is null then true else false end,
+                                             case when r.id is not null then true else false end
 			                     )
 			from MemberEntity m
 			                     left join ScheduleShareEntity s
@@ -72,84 +74,92 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 	List<ScheduleShareUserDTO> searchAvailableForRequest(@Param("sharerId") Long sharerId, @Param("name") String name);
 
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.id,
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    false,
-			    false
-			)
-			from ScheduleShareEntity s
-			join MemberEntity m on m.id = s.sharerId
-			where s.receiverId = :receiverId
-			  and s.acceptYn = 'N'
-			  and s.actionType = 'I'
-			order by m.hname
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            l.title,
+                            false,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.sharerId
+                        join ScheduleListEntity l on l.scheduleListId = s.scheduleListId
+                        where s.receiverId = :receiverId
+                          and s.acceptYn = 'N'
+                          and s.actionType = 'I'
+                        order by m.hname
 			""")
 	List<ScheduleShareUserDTO> findPendingInvites(@Param("receiverId") Long receiverId);
 
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.id,
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    false,
-			    false
-			)
-			from ScheduleShareEntity s
-			join MemberEntity m on m.id = s.receiverId
-			where s.sharerId = :sharerId
-			  and s.acceptYn = 'N'
-			  and s.actionType = 'R'
-			order by m.hname
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            l.title,
+                            false,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.receiverId
+                        join ScheduleListEntity l on l.scheduleListId = s.scheduleListId
+                        where s.sharerId = :sharerId
+                          and s.acceptYn = 'N'
+                          and s.actionType = 'R'
+                        order by m.hname
 			""")
 	List<ScheduleShareUserDTO> findPendingRequests(@Param("sharerId") Long sharerId);
 
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.id,
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    false,
-			    false
-			)
-			from ScheduleShareEntity s
-			join MemberEntity m on m.id = s.receiverId
-			where s.sharerId = :sharerId
-			  and s.acceptYn = 'Y'
-			order by m.hname
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            l.title,
+                            false,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.receiverId
+                        join ScheduleListEntity l on l.scheduleListId = s.scheduleListId
+                        where s.sharerId = :sharerId
+                          and s.acceptYn = 'Y'
+                        order by m.hname
 			""")
 	List<ScheduleShareUserDTO> findAcceptedShares(@Param("sharerId") Long sharerId);
 
 	@Query("""
-			select new com.keep.share.dto.ScheduleShareUserDTO(
-			    s.id,
-			    s.sharerId,
-			    s.receiverId,
-			    s.canEdit,
-			    s.acceptYn,
-			    m.id,
-			    m.hname,
-			    false,
-			    false
-			)
-			from ScheduleShareEntity s
-			join MemberEntity m on m.id = s.sharerId
-			where s.receiverId = :receiverId
-			  and s.acceptYn = 'Y'
-			order by m.hname
+                        select new com.keep.share.dto.ScheduleShareUserDTO(
+                            s.id,
+                            s.sharerId,
+                            s.receiverId,
+                            s.canEdit,
+                            s.acceptYn,
+                            m.id,
+                            m.hname,
+                            l.title,
+                            false,
+                            false
+                        )
+                        from ScheduleShareEntity s
+                        join MemberEntity m on m.id = s.sharerId
+                        join ScheduleListEntity l on l.scheduleListId = s.scheduleListId
+                        where s.receiverId = :receiverId
+                          and s.acceptYn = 'Y'
+                        order by m.hname
 			""")
 	List<ScheduleShareUserDTO> findAcceptedReceived(@Param("receiverId") Long receiverId);
 

--- a/keep/src/main/resources/static/js/main/share/components/share-manage.js
+++ b/keep/src/main/resources/static/js/main/share/components/share-manage.js
@@ -95,7 +95,7 @@
 					const div = document.createElement('div');
 					div.className = 'list-item';
                                         const nameSpan = document.createElement('span');
-                                        nameSpan.textContent = m.title ? `${m.hname} - ${m.title}` : m.hname;
+                                        nameSpan.textContent = m.title ? `${m.hname} | ${m.title}` : m.hname;
                                         div.appendChild(nameSpan);
 					const action = document.createElement('div');
 					const readBtn = document.createElement('button');
@@ -134,7 +134,7 @@
 					const div = document.createElement('div');
 					div.className = 'list-item';
                                         const nameSpan = document.createElement('span');
-                                        nameSpan.textContent = m.title ? `${m.hname} - ${m.title}` : m.hname;
+                                        nameSpan.textContent = m.title ? `${m.hname} | ${m.title}` : m.hname;
                                         div.appendChild(nameSpan);
 					const action = document.createElement('div');
 					const acceptBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- extend `ScheduleShareUserDTO` with `title`
- include schedule list title in repository queries
- show title next to user name in share manage page using `|` separator

## Testing
- `gradle test` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c86aadbe08327ba8bb67db9898097