### PR TITLE
Improve share list readability

### DIFF
--- a/keep/src/main/resources/static/css/main/share/components/share-list.css
+++ b/keep/src/main/resources/static/css/main/share/components/share-list.css
@@ -18,3 +18,19 @@
 .list-item:hover {
   background-color: #f5f5f5;
 }
+
+/* emphasize schedule title over user name */
+.item-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.item-info .schedule-title {
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.item-info .user-name {
+  font-size: 0.9rem;
+  color: #6b7280;
+}


### PR DESCRIPTION
## Summary
- style share list so schedule title is bold and username appears lighter

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c90f176bc83278897492ec07ae9ef