### PR TITLE
Show shared schedules in list dropdown

### DIFF
--- a/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
+++ b/keep/src/main/java/com/keep/share/repository/ScheduleShareRepository.java
@@ -185,4 +185,7 @@ public interface ScheduleShareRepository extends JpaRepository<ScheduleShareEnti
 
         List<ScheduleShareEntity> findBySharerIdInAndReceiverIdAndScheduleListIdIn(List<Long> sharerIds,
                         Long receiverId, List<Long> scheduleListIds);
+
+        @Query("select s.scheduleListId from ScheduleShareEntity s where s.receiverId = :receiverId and s.acceptYn = 'Y'")
+        List<Long> findAcceptedScheduleListIdsByReceiverId(@Param("receiverId") Long receiverId);
 }


### PR DESCRIPTION
## Summary
- expose schedule list IDs for accepted shares
- include shared schedules in schedule list dropdown API

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c1b3b7083278036a28c0ef39be5