### PR TITLE
Implement read‑only mode for shared schedules

### DIFF
--- a/keep/src/main/java/com/keep/schedulelist/dto/ScheduleListDTO.java
+++ b/keep/src/main/java/com/keep/schedulelist/dto/ScheduleListDTO.java
@@ -15,4 +15,5 @@ public class ScheduleListDTO {
     private String isShareable;
     private Long userId;
     private String hname;
+    private String canEdit;
 }

--- a/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapperImpl.java
+++ b/keep/src/main/java/com/keep/schedulelist/mapper/ScheduleListMapperImpl.java
@@ -29,6 +29,7 @@ public class ScheduleListMapperImpl implements ScheduleListMapper {
                 .isShareable(entity.getIsShareable())
                 .userId(entity.getUserId())
                 .hname(null)
+                .canEdit(null)
                 .build();
     }
 }

--- a/keep/src/main/java/com/keep/schedulelist/service/ScheduleListService.java
+++ b/keep/src/main/java/com/keep/schedulelist/service/ScheduleListService.java
@@ -5,6 +5,7 @@ import com.keep.schedulelist.entity.ScheduleListEntity;
 import com.keep.schedulelist.mapper.ScheduleListMapper;
 import com.keep.schedulelist.repository.ScheduleListRepository;
 import com.keep.share.repository.ScheduleShareRepository;
+import com.keep.share.entity.ScheduleShareEntity;
 import com.keep.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import jakarta.persistence.EntityNotFoundException;
@@ -51,7 +52,10 @@ public class ScheduleListService {
         String myName = memberRepository.findById(userId)
                 .map(m -> m.getHname())
                 .orElse(null);
-        result.forEach(dto -> dto.setHname(myName));
+        result.forEach(dto -> {
+            dto.setHname(myName);
+            dto.setCanEdit("Y");
+        });
 
         List<Long> sharedIds = shareRepository.findAcceptedScheduleListIdsByReceiverId(userId);
         if (!sharedIds.isEmpty()) {
@@ -61,6 +65,10 @@ public class ScheduleListService {
                         memberRepository.findById(dto.getUserId())
                                 .map(m -> m.getHname())
                                 .ifPresent(dto::setHname);
+                        shareRepository
+                                .findFirstBySharerIdAndReceiverIdAndScheduleListId(dto.getUserId(), userId, dto.getScheduleListId())
+                                .map(ScheduleShareEntity::getCanEdit)
+                                .ifPresent(dto::setCanEdit);
                         result.add(dto);
                     });
         }

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
@@ -110,10 +110,11 @@
 			.getPropertyValue('--hour-height'));
 		STEP = H / 4;
 
-		grid.addEventListener('pointerdown', e => {
-			const evEl = e.target.closest('.event');
-			if (!evEl) return;
-			e.preventDefault();
+                grid.addEventListener('pointerdown', e => {
+                        if (window.currentCanEdit !== 'Y') return;
+                        const evEl = e.target.closest('.event');
+                        if (!evEl) return;
+                        e.preventDefault();
 
 			draggingEvt = evEl;
 			isDragging = false;                    // 아직 드래그 안 함
@@ -380,8 +381,9 @@
 			openModalWithRange(top, bottom);
 		}
 
-		grid.addEventListener('pointerdown', e => {
-			if (e.target.closest('.event')) return;
+                grid.addEventListener('pointerdown', e => {
+                        if (window.currentCanEdit !== 'Y') return;
+                        if (e.target.closest('.event')) return;
 			const slot = e.target.closest('.hour-slot');
 			if (!slot) return;
 			const hourSlots = Array.from(grid.querySelectorAll('.hour-slot'));
@@ -406,8 +408,9 @@
 
 		document.addEventListener('scheduleModalClosed', cancelSelection);
 
-		grid.addEventListener('click', e => {
-			if (selecting) return; // drag selection handled separately
+                grid.addEventListener('click', e => {
+                        if (window.currentCanEdit !== 'Y') return;
+                        if (selecting) return; // drag selection handled separately
 			const slot = e.target.closest('.hour-slot');
 			if (!slot) return;
 			const hourSlots = Array.from(grid.querySelectorAll('.hour-slot'));

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
@@ -384,8 +384,9 @@
 
 	let dragState = null;
 
-	function monthlyPointerDown(e) {
-		const bar = e.currentTarget;
+        function monthlyPointerDown(e) {
+                if (window.currentCanEdit !== 'Y') return;
+                const bar = e.currentTarget;
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -588,8 +589,9 @@
 			document.removeEventListener('pointercancel', cancel);
 		}
 
-		calendar.addEventListener('pointerdown', e => {
-			if (e.target.closest('.event-bar') || e.target.classList.contains('more-link')) return;
+                calendar.addEventListener('pointerdown', e => {
+                        if (window.currentCanEdit !== 'Y') return;
+                        if (e.target.closest('.event-bar') || e.target.classList.contains('more-link')) return;
 			const cell = e.target.closest('.day-cell');
 			if (!cell || cell.classList.contains('other-month')) return;
 			e.preventDefault();

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
@@ -276,6 +276,7 @@
 		});
 
                 function pointerDownHandler(e) {
+                        if (window.currentCanEdit !== 'Y') return;
                         e.preventDefault();
                         e.stopPropagation();
 
@@ -681,6 +682,7 @@
                 }
 
                 grid.addEventListener('pointerdown', e => {
+                        if (window.currentCanEdit !== 'Y') return;
                         if (e.target.closest('.event')) return;
                         const slot = e.target.closest('.hour-slot');
                         if (!slot) return;
@@ -715,6 +717,7 @@
                 document.addEventListener('scheduleModalClosed', cancelSelection);
 
                 grid.addEventListener('click', e => {
+                        if (window.currentCanEdit !== 'Y') return;
                         if (selecting) return; // drag selection handled separately
                         const slot = e.target.closest('.hour-slot');
                         if (!slot) return;

--- a/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/modal/schedule-modal.js
@@ -202,10 +202,23 @@
 	// ────────────────────────────────────────────────────────────────────────
 
         function openModal() {
+                const form = document.getElementById('schedule-form');
                 const delBtn = document.getElementById('modal-delete');
+                const submitBtn = form.querySelector('button[type="submit"]');
+                const readonly = window.currentScheduleOwnerId !== window.currentUserId || window.currentCanEdit !== 'Y';
+                form.querySelectorAll('input, select, textarea').forEach(el => {
+                        if (readonly) {
+                                el.setAttribute('readonly', 'readonly');
+                                el.disabled = true;
+                        } else {
+                                el.removeAttribute('readonly');
+                                el.disabled = false;
+                        }
+                });
                 if (delBtn) {
-                       delBtn.classList.toggle('hidden', !document.getElementById('sched-id').value);
+                        delBtn.classList.toggle('hidden', readonly || !document.getElementById('sched-id').value);
                 }
+                if (submitBtn) submitBtn.classList.toggle('hidden', readonly);
                 if (listIdInput) {
                         const hiddenInput = document.getElementById('current-schedule-list-id');
                         if (hiddenInput && hiddenInput.value) {
@@ -221,7 +234,7 @@
                 document.querySelector('.cat-color[data-color="' + hiddenColorInput.value + '"]')
                         ?.classList.add('selected');
         }
-		
+
         function closeModal() {
                 document.getElementById('schedule-modal-overlay').classList.add('hidden');
                 document.getElementById('schedule-modal').classList.add('hidden');
@@ -230,7 +243,14 @@
                 if (listIdInput) listIdInput.value = '';
                 document.querySelectorAll('.cat-color').forEach(b => b.classList.remove('selected'));
                 const delBtn = document.getElementById('modal-delete');
+                const form = document.getElementById('schedule-form');
+                const submitBtn = form.querySelector('button[type="submit"]');
                 delBtn?.classList.add('hidden');
+                submitBtn?.classList.remove('hidden');
+                form.querySelectorAll('input, select, textarea').forEach(el => {
+                        el.removeAttribute('readonly');
+                        el.disabled = false;
+                });
                 document.dispatchEvent(new Event('scheduleModalClosed'));
         }
 

--- a/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
@@ -12,14 +12,19 @@
                 opt.value = l.scheduleListId;
                 opt.textContent = l.hname ? `${l.hname} : ${l.title}` : l.title;
                 opt.dataset.share = l.isShareable;
+                opt.dataset.owner = l.userId;
+                opt.dataset.canEdit = l.canEdit || 'N';
                 opt.classList.add(l.isShareable === 'Y' ? 'share-yes' : 'share-no');
                 select.appendChild(opt);
             });
             if (data.length > 0) {
-                select.value = data[0].scheduleListId;
-                window.currentScheduleListId = data[0].scheduleListId;
+                const first = data[0];
+                select.value = first.scheduleListId;
+                window.currentScheduleListId = first.scheduleListId;
+                window.currentScheduleOwnerId = first.userId;
+                window.currentCanEdit = first.canEdit || 'N';
                 const hiddenInput = document.getElementById('current-schedule-list-id');
-                if (hiddenInput) hiddenInput.value = data[0].scheduleListId;
+                if (hiddenInput) hiddenInput.value = first.scheduleListId;
                 if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
             }
         } catch (e) {
@@ -73,6 +78,8 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
+        const userEl = document.querySelector('.notification[data-user-id]');
+        if (userEl) window.currentUserId = Number(userEl.dataset.userId);
         const select = document.getElementById('schedule-list-select');
         const addBtn = document.getElementById('schedule-list-add');
         const editBtn = document.getElementById('schedule-list-edit');
@@ -80,9 +87,12 @@
         const cancelBtn = document.getElementById('schedule-list-cancel');
         const overlay = document.getElementById('schedule-list-modal-overlay');
         select && select.addEventListener('change', () => {
-            window.currentScheduleListId = select.value;
+            const opt = select.options[select.selectedIndex];
+            window.currentScheduleListId = opt.value;
+            window.currentScheduleOwnerId = Number(opt.dataset.owner);
+            window.currentCanEdit = opt.dataset.canEdit || 'N';
             const hiddenInput = document.getElementById('current-schedule-list-id');
-            if (hiddenInput) hiddenInput.value = select.value;
+            if (hiddenInput) hiddenInput.value = opt.value;
             if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
         });
         addBtn && addBtn.addEventListener('click', () => openModal(false));


### PR DESCRIPTION
## Summary
- add `canEdit` flag to `ScheduleListDTO`
- propagate new flag in mapper and service
- expose owner and permission info on schedule list dropdown
- disable drag and new-schedule actions when sharing is read only
- make schedule modal read-only when viewer lacks edit rights

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c9fe5aa548327b02d6813bfb8a0b8