### PR TITLE
Fix dashboard fade-in

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/dashboard.js
+++ b/keep/src/main/resources/static/js/main/dashboard/dashboard.js
@@ -139,11 +139,12 @@ document.addEventListener('DOMContentLoaded', () => {
                         if (window.initMonthlyMoreModal) {
                                 window.initMonthlyMoreModal();
                         }
+                } catch (err) {
+                        console.error(err);
+                } finally {
                         requestAnimationFrame(() => {
                                 fragmentContainer.style.opacity = 1;
                         });
-                } catch (err) {
-                        console.error(err);
                 }
         }
 


### PR DESCRIPTION
## Summary
- ensure dashboard fragment fades in even if view load fails

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ddc8596808327995163c14b65fa25