### PR TITLE
Fix fragment opacity reset

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/dashboard.js
+++ b/keep/src/main/resources/static/js/main/dashboard/dashboard.js
@@ -99,7 +99,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const link = document.getElementById(id);
                 return new Promise(resolve => {
                         if (!link || link.sheet) return resolve();
-                        link.addEventListener('load', () => resolve(), { once: true });
+                        const timer = setTimeout(resolve, 3000);
+                        link.addEventListener('load', () => {
+                                clearTimeout(timer);
+                                resolve();
+                        }, { once: true });
                 });
         }
 


### PR DESCRIPTION
## Summary
- avoid infinite wait when re-enabling dashboard view css

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ddfdf23ec83278935471fa2d3171c