### PR TITLE
Fix events container null guard

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
@@ -47,8 +47,12 @@
 		renderAllDayEvents(allDayEvents, weekStart, weekEnd);
 
 		// 3) 기존 이벤트 제거 & 현재시간선 업데이트
-		const container = document.querySelector('.events-container');
-		container.innerHTML = '';
+                const container = document.querySelector('.events-container');
+                if (!container) {
+                        console.warn('events-container element not found');
+                        return;
+                }
+                container.innerHTML = '';
 		updateCurrentTimeLine();
 		// CSS 변수 읽기
 		const slotHeight = parseFloat(


### PR DESCRIPTION
## Summary
- avoid crashing when weekly events container is missing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685deb69f8848327ab8e96e8420e2751