### PR TITLE
Fix initDailySchedule double execution

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/schedule-list.js
@@ -55,10 +55,10 @@
                 window.currentCanEdit = first.canEdit || 'N';
                 const hiddenInput = document.getElementById('current-schedule-list-id');
                 if (hiddenInput) hiddenInput.value = first.scheduleListId;
-                if (typeof window.refreshSchedule === 'function') window.refreshSchedule();
                 connectScheduleSocket(first.scheduleListId);
                 updateEditButton();
             }
+            document.dispatchEvent(new Event('scheduleListsLoaded'));
         } catch (e) {
             console.error(e);
         }

--- a/keep/src/main/resources/static/js/main/dashboard/dashboard.js
+++ b/keep/src/main/resources/static/js/main/dashboard/dashboard.js
@@ -147,8 +147,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	}
 
-	// 초기 로드
-	loadView(initialView || 'daily');
+        // 일정 목록이 준비되면 초기 뷰 로드
+        document.addEventListener('scheduleListsLoaded', () => {
+                loadView(initialView || 'daily');
+        }, { once: true });
 
 	// 뷰 버튼 이벤트
 	viewBtns.forEach(btn => {


### PR DESCRIPTION
## Summary
- avoid calling `initDailySchedule` twice on dashboard load
- dispatch a `scheduleListsLoaded` event once lists are fetched
- wait for that event before loading the initial dashboard view

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e1b436c008327a687726e76ae2cf8