### PR TITLE
Fix monthly drag select label and overlay visibility

### DIFF
--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
@@ -245,12 +245,12 @@
 
 /* 드래그 선택 영역 */
 .drag-select {
-	position: absolute;
-	left: 0;
-	right: 0;
-	background: rgba(59, 130, 246, 0.3);
-	pointer-events: none;
-	z-index: 5;
+        position: absolute;
+        left: 0;
+        right: 0;
+        background: rgba(59, 130, 246, 0.3);
+        pointer-events: none;
+        z-index: 60;
 }
 
 .drag-select::after {

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
@@ -132,14 +132,14 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  z-index: 2;
+  z-index: 50;
 }
 
 .monthly-select-overlay .drag-select {
   position: absolute;
   background: rgba(59, 130, 246, 0.3);
   pointer-events: none;
-  z-index: 5;
+  z-index: 60;
 }
 
 .monthly-select-overlay .drag-select::after {

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
@@ -305,7 +305,7 @@
   right: 0;
   background: rgba(59, 130, 246, 0.3);
   pointer-events: none;
-  z-index: 5;
+  z-index: 60;
 }
 .drag-select::after {
   content: attr(data-time);

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
@@ -640,6 +640,7 @@
                         let sIdx = Math.floor((start - base) / 86400000);
                         const eIdx = Math.floor((end - base) / 86400000);
                         const calRect = calendar.getBoundingClientRect();
+                        let first = true;
                         while (sIdx <= eIdx) {
                                 const weekIdx = Math.floor(sIdx / 7);
                                 const weekEnd = (weekIdx + 1) * 7 - 1;
@@ -661,7 +662,10 @@
                                         div.style.top = (r1.top - calRect.top) + 'px';
                                         div.style.width = (r2.right - r1.left) + 'px';
                                         div.style.height = r1.height + 'px';
-                                        div.dataset.range = formatRange(start, end);
+                                        if (first) {
+                                                div.dataset.range = formatRange(start, end);
+                                                first = false;
+                                        }
                                         overlay.appendChild(div);
                                         selectDivs.push(div);
                                 }


### PR DESCRIPTION
## Summary
- show range label only once when selecting multiple weeks in monthly view
- raise drag-select overlay z-index so it is visible above day labels

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861df98c6648327b1b81c5a88dfdb70