### PR TITLE
Fix drag selection bounds in calendars

### DIFF
--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
@@ -380,17 +380,21 @@
 			}
 		}
 
-		function pointerMove(eMove) {
-			if (!selecting) {
-				return;
-			}
-			const cur = eMove.clientY - grid.getBoundingClientRect().top;
-			const top = Math.min(startY, cur);
-			const bottom = Math.max(startY, cur);
-			selectDiv.style.top = `${top}px`;
-			selectDiv.style.height = `${bottom - top}px`;
-			selectDiv.dataset.time = `${formatTime(top)} - ${formatTime(bottom)}`;
-		}
+                function pointerMove(eMove) {
+                        if (!selecting) {
+                                return;
+                        }
+                        eMove.preventDefault();
+                        const rect = grid.getBoundingClientRect();
+                        let cur = eMove.clientY - rect.top;
+                        const maxY = 24 * H;
+                        cur = Math.max(0, Math.min(maxY, cur));
+                        const top = Math.min(startY, cur);
+                        const bottom = Math.max(startY, cur);
+                        selectDiv.style.top = `${top}px`;
+                        selectDiv.style.height = `${bottom - top}px`;
+                        selectDiv.dataset.time = `${formatTime(top)} - ${formatTime(bottom)}`;
+                }
 
 		function cancelSelection() {
 			if (!selecting) {
@@ -405,42 +409,46 @@
 			selecting = false;
 		}
 
-		function pointerUp(eUp) {
-			if (!selecting) {
-				return;
-			}
-			document.removeEventListener('pointermove', pointerMove);
-			document.removeEventListener('pointerup', pointerUp);
-			document.removeEventListener('pointercancel', cancelSelection);
-			const cur = eUp.clientY - grid.getBoundingClientRect().top;
-			let top = Math.min(startY, cur);
-			let bottom = Math.max(startY, cur);
-			top = Math.max(0, Math.round(top / STEP) * STEP);
-			bottom = Math.min(24 * H, Math.round(bottom / STEP) * STEP);
-			selectDiv.remove();
-			selecting = false;
-			openModalWithRange(top, bottom);
-		}
+                function pointerUp(eUp) {
+                        if (!selecting) {
+                                return;
+                        }
+                        document.removeEventListener('pointermove', pointerMove);
+                        document.removeEventListener('pointerup', pointerUp);
+                        document.removeEventListener('pointercancel', cancelSelection);
+                        const rect = grid.getBoundingClientRect();
+                        let cur = eUp.clientY - rect.top;
+                        const maxY = 24 * H;
+                        cur = Math.max(0, Math.min(maxY, cur));
+                        let top = Math.min(startY, cur);
+                        let bottom = Math.max(startY, cur);
+                        top = Math.max(0, Math.round(top / STEP) * STEP);
+                        bottom = Math.min(maxY, Math.round(bottom / STEP) * STEP);
+                        selectDiv.remove();
+                        selecting = false;
+                        openModalWithRange(top, bottom);
+                }
 
-		grid.addEventListener('pointerdown', e => {
-			if (window.currentCanEdit !== 'Y') {
-				return;
-			}
-			if (e.target.closest('.event')) {
-				return;
-			}
-			const slot = e.target.closest('.hour-slot');
-			if (!slot) {
-				return;
-			}
-			const hourSlots = Array.from(grid.querySelectorAll('.hour-slot'));
-			const idx = hourSlots.indexOf(slot);
-			if (idx === hourSlots.length - 1) {
-				return;
-			}
-			selecting = true;
-			startY = e.clientY - grid.getBoundingClientRect().top;
-			selectDiv = document.createElement('div');
+                grid.addEventListener('pointerdown', e => {
+                        if (window.currentCanEdit !== 'Y') {
+                                return;
+                        }
+                        if (e.target.closest('.event')) {
+                                return;
+                        }
+                        const slot = e.target.closest('.hour-slot');
+                        if (!slot) {
+                                return;
+                        }
+                        const hourSlots = Array.from(grid.querySelectorAll('.hour-slot'));
+                        const idx = hourSlots.indexOf(slot);
+                        if (idx === hourSlots.length - 1) {
+                                return;
+                        }
+                        e.preventDefault();
+                        selecting = true;
+                        startY = e.clientY - grid.getBoundingClientRect().top;
+                        selectDiv = document.createElement('div');
 			selectDiv.className = 'drag-select';
 			selectDiv.style.top = `${startY}px`;
 			grid.appendChild(selectDiv);

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
@@ -677,7 +677,11 @@
                         if (!selecting) {
                                 return;
                         }
-                        const el = document.elementFromPoint(eMove.clientX, eMove.clientY);
+                        eMove.preventDefault();
+                        const rect = calendar.getBoundingClientRect();
+                        const x = Math.max(rect.left + 1, Math.min(rect.right - 1, eMove.clientX));
+                        const y = Math.max(rect.top + 1, Math.min(rect.bottom - 1, eMove.clientY));
+                        const el = document.elementFromPoint(x, y);
                         const cell = el ? el.closest('.day-cell') : null;
                         renderSelection(cell || startCell);
                 }
@@ -691,7 +695,11 @@
                         }
                         selecting = false;
                         clearDivs();
-                        const endCell = e.target.closest('.day-cell') || startCell;
+                        const rect = calendar.getBoundingClientRect();
+                        const x = Math.max(rect.left + 1, Math.min(rect.right - 1, e.clientX));
+                        const y = Math.max(rect.top + 1, Math.min(rect.bottom - 1, e.clientY));
+                        const el = document.elementFromPoint(x, y);
+                        const endCell = (el ? el.closest('.day-cell') : null) || startCell;
                         if (!endCell || !startCell) {
                                 return;
                         }


### PR DESCRIPTION
## Summary
- keep drag selection inside daily grid
- prevent text selection while dragging
- clamp monthly range selection to calendar bounds

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861e38e34808327a9b88c92cb7cc27b