### PR TITLE
Fix monthly drag overlay and label position

### DIFF
--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
@@ -254,14 +254,14 @@
 }
 
 .drag-select::after {
-	content: attr(data-time);
-	position: absolute;
-	top: -18px;
-	left: 0;
-	background: rgba(59, 130, 246, 0.9);
-	color: #fff;
-	font-size: 0.75rem;
-	padding: 2px 4px;
-	border-radius: 4px;
-	white-space: nowrap;
+        content: attr(data-time);
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        background: rgba(59, 130, 246, 0.9);
+        color: #fff;
+        font-size: 0.75rem;
+        padding: 2px 4px;
+        border-radius: 4px;
+        white-space: nowrap;
 }

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
@@ -145,8 +145,8 @@
 .monthly-select-overlay .drag-select::after {
   content: attr(data-range);
   position: absolute;
-  top: -18px;
-  left: 0;
+  top: 2px;
+  left: 2px;
   background: rgba(59, 130, 246, 0.9);
   color: #fff;
   font-size: 0.75rem;

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
@@ -310,8 +310,8 @@
 .drag-select::after {
   content: attr(data-time);
   position: absolute;
-  top: -18px;
-  left: 0;
+  top: 2px;
+  left: 2px;
   background: rgba(59, 130, 246, 0.9);
   color: #fff;
   font-size: 0.75rem;

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-monthly.js
@@ -670,6 +670,7 @@
                                         selectDivs.push(div);
                                 }
                                 sIdx = partEnd + 1;
+                                break; // show only the first row selection
                         }
                 }
 


### PR DESCRIPTION
## Summary
- adjust drag-select tooltip placement inside cell boxes
- limit monthly drag selection overlay to the first row

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861e5248dec8327bbe2dbd97d9e0427