### PR TITLE
Add mobile responsive styles

### DIFF
--- a/keep/src/main/resources/static/css/fragments/body.css
+++ b/keep/src/main/resources/static/css/fragments/body.css
@@ -239,3 +239,54 @@ header .head h1 {
   font-size: 0.9rem;
   color: #777;
 }
+
+/* 모바일 접근성 향상을 위한 기본 버튼/링크 터치 영역 */
+button, a {
+  min-width: 48px;
+  min-height: 48px;
+  padding: 0.5rem 0.75rem;
+}
+
+/* 반응형 레이아웃 */
+@media (max-width: 992px) {
+  #sidebar {
+    width: 200px;
+  }
+  .content {
+    padding: 15px;
+  }
+  html {
+    font-size: 15px;
+  }
+}
+
+@media (max-width: 768px) {
+  #container {
+    flex-direction: column;
+  }
+  #sidebar {
+    width: 100%;
+  }
+  #sidebar.collapsed {
+    width: 100%;
+  }
+  .content {
+    border-radius: 0;
+  }
+}
+
+@media (max-width: 576px) {
+  header .head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  #sidebar {
+    display: none;
+  }
+  #sidebar.collapsed {
+    display: none;
+  }
+  .content {
+    padding: 10px;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-daily.css
@@ -265,3 +265,16 @@
         border-radius: 4px;
         white-space: nowrap;
 }
+
+/* Responsive: single column layout on narrow screens */
+@media (max-width: 576px) {
+  :root {
+    --hour-height: 40px;
+  }
+  .daily-schedule {
+    flex-direction: column;
+  }
+  .schedule-grid {
+    overflow-x: auto;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-monthly.css
@@ -154,3 +154,13 @@
   border-radius: 4px;
   white-space: nowrap;
 }
+
+/* Responsive: reduce cell height on narrow screens */
+@media (max-width: 576px) {
+  :root {
+    --monthly-cell-height: 80px;
+  }
+  .monthly-calendar {
+    font-size: 0.75rem;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
+++ b/keep/src/main/resources/static/css/main/dashboard/components/dashboard-weekly.css
@@ -319,3 +319,17 @@
   border-radius: 4px;
   white-space: nowrap;
 }
+
+/* Responsive: horizontal scroll on narrow screens */
+@media (max-width: 576px) {
+  :root {
+    --hour-height: 40px;
+  }
+  .weekday-header,
+  .schedule-grid {
+    min-width: 700px;
+  }
+  .daily-schedule {
+    overflow-x: auto;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/modal/location-sidebar.css
+++ b/keep/src/main/resources/static/css/main/dashboard/modal/location-sidebar.css
@@ -83,3 +83,10 @@
 #location-sidebar-close:hover {
   background: #e5e7eb;
 }
+
+/* Responsive: fullscreen sidebar on small screens */
+@media (max-width: 576px) {
+  .location-sidebar {
+    width: 100%;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/modal/monthly-more-modal.css
+++ b/keep/src/main/resources/static/css/main/dashboard/modal/monthly-more-modal.css
@@ -58,3 +58,14 @@
 #monthly-more-close:hover {
   background: #e5e7eb;
 }
+
+/* Responsive: fullscreen modal on small screens */
+@media (max-width: 576px) {
+  #monthly-more-modal {
+    width: 100%;
+    height: 100%;
+    transform: translateX(0);
+    top: 0;
+    left: 0;
+  }
+}

--- a/keep/src/main/resources/static/css/main/dashboard/modal/schedule-modal.css
+++ b/keep/src/main/resources/static/css/main/dashboard/modal/schedule-modal.css
@@ -244,3 +244,16 @@
   cursor: pointer;
 }
 
+
+/* Responsive: fullscreen modal on small screens */
+@media (max-width: 576px) {
+  .modal {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transform: none;
+    border-radius: 0;
+    overflow-y: auto;
+  }
+}

--- a/keep/src/main/resources/templates/fragments/header.html
+++ b/keep/src/main/resources/templates/fragments/header.html
@@ -3,7 +3,8 @@
 	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <header th:fragment="main-head" class="app-header">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<th:block layout:fragment="title"></th:block>
 


### PR DESCRIPTION
## Summary
- apply viewport meta tag
- enforce touch target size and add responsive layout breakpoints
- adapt calendar views and modals for small screens

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee0dc530832789eb6ecfaf759fd6