### PR TITLE
Fix responsive header and JS rem handling

### DIFF
--- a/keep/src/main/resources/static/css/main/dashboard/dashboard.css
+++ b/keep/src/main/resources/static/css/main/dashboard/dashboard.css
@@ -129,4 +129,18 @@
     align-items: stretch;
     gap: 1rem;
   }
+  .dashboard-header-left,
+  .dashboard-header-center,
+  .dashboard-header-right {
+    width: 100%;
+  }
+  .dashboard-header-left {
+    justify-content: flex-start;
+  }
+  .dashboard-header-center {
+    justify-content: center;
+  }
+  .dashboard-header-right {
+    justify-content: flex-end;
+  }
 }

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-daily.js
@@ -1,9 +1,18 @@
 // static/js/main/dashboard/components/dashboard-daily.js
 (function() {
-	let draggingEvt = null;
-	let ghostEl = null;
-	let startY, origTop;
-	let H, STEP;
+        let draggingEvt = null;
+        let ghostEl = null;
+        let startY, origTop;
+        let H, STEP;
+        function cssVarPx(name) {
+                const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+                const num = parseFloat(val);
+                if (val.endsWith('rem')) {
+                        const base = parseFloat(getComputedStyle(document.documentElement).fontSize);
+                        return num * base;
+                }
+                return num;
+        }
 	let isDragging = false;               // 실제 드래그 중인지 플래그
 	const DRAG_THRESHOLD = 5;
 
@@ -112,9 +121,8 @@
 			return;
 		}
 
-		H = parseFloat(getComputedStyle(document.documentElement)
-			.getPropertyValue('--hour-height'));
-		STEP = H / 4;
+                H = cssVarPx('--hour-height');
+                STEP = H / 4;
 
 		grid.addEventListener('pointerdown', e => {
 			if (window.currentCanEdit !== 'Y') {
@@ -147,8 +155,8 @@
 		if (oldToggle) {
 			oldToggle.remove();
 		}
-		const ROW_HEIGHT = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--all-day-row-height') || 20);
-		const ROW_GAP = 2;
+                const ROW_HEIGHT = cssVarPx('--all-day-row-height');
+                const ROW_GAP = 2;
 
 		const dayStart = new Date(dateStr + 'T00:00:00');
 		const dayEnd = new Date(dayStart);
@@ -289,8 +297,8 @@
 		const container = grid.querySelector('.events-container');
 		container.innerHTML = '';
 		updateCurrentTimeLine();
-		const H = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--hour-height'));
-		const GAP = 2;
+                const H = cssVarPx('--hour-height');
+                const GAP = 2;
 
 		events.forEach(evt => {
 			const startDate = new Date(evt.startTs);
@@ -321,9 +329,8 @@
 		}
 		const now = new Date();
 		const h = now.getHours() + now.getMinutes() / 60;
-		const H = parseFloat(getComputedStyle(document.documentElement)
-			.getPropertyValue('--hour-height'));
-		line.style.top = `${h * H}px`;
+                const H = cssVarPx('--hour-height');
+                line.style.top = `${h * H}px`;
 		const pad = n => String(n).padStart(2, '0');
 		line.dataset.time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
 	}
@@ -333,8 +340,8 @@
 		if (!grid || grid.dataset.modalClickAttached) {
 			return;
 		}
-		const H = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--hour-height'));
-		const STEP = H / 4;
+                const H = cssVarPx('--hour-height');
+                const STEP = H / 4;
 		let selecting = false;
 		let startY = 0;
 		let selectDiv = null;

--- a/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
+++ b/keep/src/main/resources/static/js/main/dashboard/components/dashboard-weekly.js
@@ -5,6 +5,15 @@
  */
 
 (function() {
+        function cssVarPx(name) {
+                const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+                const num = parseFloat(val);
+                if (val.endsWith('rem')) {
+                        const base = parseFloat(getComputedStyle(document.documentElement).fontSize);
+                        return num * base;
+                }
+                return num;
+        }
 	/**
 	 * initWeeklySchedule:
 	 *  1) 주간 시작·끝 날짜 계산
@@ -55,10 +64,8 @@
                 container.innerHTML = '';
 		updateCurrentTimeLine();
 		// CSS 변수 읽기
-		const slotHeight = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
-		);
-		const percentPerDay = 100 / 7;
+                const slotHeight = cssVarPx('--hour-height');
+                const percentPerDay = 100 / 7;
 
 		attachGridClick();
 
@@ -266,14 +273,10 @@
 		}
 		window.addEventListener('resize', updateGridRect);
 
-		const slotHeight = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
-		);
-		const quarterSlot = slotHeight / 4;                     // 15분 단위
-		const bottomSlotHeight = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--bottom-slot-height')
-		);
-		const totalGridHeight = 24 * slotHeight + bottomSlotHeight;
+                const slotHeight = cssVarPx('--hour-height');
+                const quarterSlot = slotHeight / 4;                     // 15분 단위
+                const bottomSlotHeight = cssVarPx('--bottom-slot-height');
+                const totalGridHeight = 24 * slotHeight + bottomSlotHeight;
 		const percentPerDay = 100 / 7;
 
                 let originals, pressedPointerId, scheduleId, startX, startY;
@@ -476,10 +479,8 @@
                         oldToggle.remove();
                 }
 
-		const ROW_HEIGHT = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--all-day-row-height') || 20
-		);
-		const ROW_GAP = 2;
+                const ROW_HEIGHT = cssVarPx('--all-day-row-height');
+                const ROW_GAP = 2;
 		const percentPerDay = 100 / 7;
 
 		const items = events
@@ -586,9 +587,7 @@
                 }
                 const now = new Date();
                 const h = now.getHours() + now.getMinutes() / 60;
-                const slotHeight = parseFloat(
-                        getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
-                );
+                const slotHeight = cssVarPx('--hour-height');
                 line.style.top = `${h * slotHeight}px`;
 
                 const currentDateInput = document.getElementById('current-date');
@@ -643,10 +642,8 @@
                         return;
                 }
 
-		const slotHeight = parseFloat(
-			getComputedStyle(document.documentElement).getPropertyValue('--hour-height')
-		);
-		const STEP = slotHeight / 4;
+                const slotHeight = cssVarPx('--hour-height');
+                const STEP = slotHeight / 4;
 		let selecting = false;
 		let startY = 0;
 		let startColIdx = 0;


### PR DESCRIPTION
## Summary
- stack header sections vertically on mobile
- add cssVarPx helper to parse CSS variables with rem units
- use cssVarPx for layout calculations in daily/weekly JS

## Testing
- `./keep/gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6862132c24448327bd3b9e8b63b2d007