### PR TITLE
Implement responsive calendar layout

### DIFF
--- a/keep/src/main/java/com/keep/main/ResponsiveCalendarController.java
+++ b/keep/src/main/java/com/keep/main/ResponsiveCalendarController.java
@@ -1,0 +1,15 @@
+package com.keep.main;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/responsive")
+public class ResponsiveCalendarController {
+
+    @GetMapping
+    public String calendar() {
+        return "responsive/calendar";
+    }
+}

--- a/keep/src/main/resources/static/css/responsive-calendar.css
+++ b/keep/src/main/resources/static/css/responsive-calendar.css
@@ -1,0 +1,122 @@
+/* Mobile-first styles */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: #fff;
+  color: #333;
+}
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.menu-toggle {
+  font-size: 1.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: -80%;
+  width: 80%;
+  height: 100%;
+  background: #fff;
+  box-shadow: 2px 0 6px rgba(0,0,0,0.2);
+  transition: transform 0.3s ease;
+  transform: translateX(-100%);
+  z-index: 1000;
+}
+.sidebar.open {
+  transform: translateX(0);
+}
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+.close-btn {
+  align-self: flex-end;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+.icon-buttons button,
+.date-nav button,
+.view-toggle button {
+  background: #e0e7ff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+.view-toggle button.active {
+  background: #c7d2fe;
+}
+.main-content {
+  padding: 1rem;
+}
+.calendar-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
+.hours {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  margin-right: 0.5rem;
+}
+.hours .hour {
+  height: 2rem;
+}
+.days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-auto-rows: 2rem;
+  gap: 1px;
+  background: #e5e7eb;
+}
+.day {
+  background: #fff;
+}
+/* Tablet */
+@media (min-width: 481px) and (max-width: 768px) {
+  .sidebar {
+    width: 60%;
+    left: -60%;
+  }
+}
+/* Desktop */
+@media (min-width: 769px) {
+  .sidebar {
+    position: static;
+    transform: none;
+    width: 15rem;
+    height: auto;
+  }
+  .overlay { display: none; }
+  .main-layout {
+    display: flex;
+  }
+  .main-content {
+    flex: 1;
+  }
+}

--- a/keep/src/main/resources/static/js/responsive-calendar.js
+++ b/keep/src/main/resources/static/js/responsive-calendar.js
@@ -1,0 +1,55 @@
+(function(){
+  const sidebar = document.getElementById('sidebar');
+  const toggleBtn = document.getElementById('menu-toggle');
+  const closeBtn = document.getElementById('sidebar-close');
+  const overlay = document.getElementById('overlay');
+  const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  let firstFocusable, lastFocusable;
+
+  function openSidebar(){
+    sidebar.classList.add('open');
+    overlay.classList.add('active');
+    toggleBtn.setAttribute('aria-expanded','true');
+    sidebar.setAttribute('aria-hidden','false');
+    trapFocus();
+    firstFocusable.focus();
+  }
+
+  function closeSidebar(){
+    sidebar.classList.remove('open');
+    overlay.classList.remove('active');
+    toggleBtn.setAttribute('aria-expanded','false');
+    sidebar.setAttribute('aria-hidden','true');
+    toggleBtn.focus();
+  }
+
+  function trapFocus(){
+    const focusables = sidebar.querySelectorAll(focusableSelectors);
+    firstFocusable = focusables[0];
+    lastFocusable = focusables[focusables.length - 1];
+  }
+
+  toggleBtn.addEventListener('click', openSidebar);
+  closeBtn.addEventListener('click', closeSidebar);
+  overlay.addEventListener('click', closeSidebar);
+  document.addEventListener('keydown', (e)=>{
+    if(e.key === 'Escape' && sidebar.classList.contains('open')){
+      closeSidebar();
+    }
+    if(e.key === 'Tab' && sidebar.classList.contains('open')){
+      const focusables = sidebar.querySelectorAll(focusableSelectors);
+      if(focusables.length === 0) return;
+      if(e.shiftKey){
+        if(document.activeElement === firstFocusable){
+          e.preventDefault();
+          lastFocusable.focus();
+        }
+      }else{
+        if(document.activeElement === lastFocusable){
+          e.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    }
+  });
+})();

--- a/keep/src/main/resources/templates/responsive/calendar.html
+++ b/keep/src/main/resources/templates/responsive/calendar.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="layouts/layout">
+<!-- title -->
+<th:block layout:fragment="title">
+  <title>Responsive Calendar</title>
+</th:block>
+
+<!-- style -->
+<th:block layout:fragment="add-css">
+  <link rel="stylesheet" th:href="@{/css/responsive-calendar.css}" />
+</th:block>
+
+<!-- content -->
+<th:block layout:fragment="content">
+  <header class="app-header">
+    <button id="menu-toggle" class="menu-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="sidebar">&#9776;</button>
+    <h1>Calendar</h1>
+  </header>
+
+  <aside id="sidebar" class="sidebar" aria-hidden="true" aria-modal="true">
+    <div class="sidebar-content" tabindex="-1">
+      <button id="sidebar-close" class="close-btn" aria-label="Close sidebar">&times;</button>
+      <p class="greeting">Hello, User</p>
+      <nav class="icon-buttons" aria-label="Primary">
+        <button aria-label="Friends">👥</button>
+        <button aria-label="Calendar">📅</button>
+        <button aria-label="Notifications">🔔</button>
+      </nav>
+      <label for="list-select" class="list-label">Choose List</label>
+      <select id="list-select">
+        <option>Default</option>
+      </select>
+      <div class="date-nav">
+        <button id="prev-week" aria-label="Previous week">&lt;</button>
+        <span id="current-week">This Week</span>
+        <button id="next-week" aria-label="Next week">&gt;</button>
+      </div>
+      <div class="view-toggle" role="group" aria-label="View toggle">
+        <button>Today</button>
+        <button>Day</button>
+        <button class="active">Week</button>
+        <button>Month</button>
+        <button>Year</button>
+      </div>
+    </div>
+  </aside>
+
+  <main id="main-content" class="main-content" tabindex="-1">
+    <div class="calendar-grid" aria-label="Weekly calendar">
+      <div class="hours" aria-hidden="true">
+        <div class="hour">0:00</div>
+        <div class="hour">1:00</div>
+        <div class="hour">2:00</div>
+        <div class="hour">3:00</div>
+        <div class="hour">4:00</div>
+        <div class="hour">5:00</div>
+        <div class="hour">6:00</div>
+        <div class="hour">7:00</div>
+        <div class="hour">8:00</div>
+        <div class="hour">9:00</div>
+        <div class="hour">10:00</div>
+        <div class="hour">11:00</div>
+        <div class="hour">12:00</div>
+        <div class="hour">13:00</div>
+        <div class="hour">14:00</div>
+        <div class="hour">15:00</div>
+        <div class="hour">16:00</div>
+        <div class="hour">17:00</div>
+        <div class="hour">18:00</div>
+        <div class="hour">19:00</div>
+        <div class="hour">20:00</div>
+        <div class="hour">21:00</div>
+        <div class="hour">22:00</div>
+        <div class="hour">23:00</div>
+      </div>
+      <div class="days">
+        <div class="day" aria-label="Sunday"></div>
+        <div class="day" aria-label="Monday"></div>
+        <div class="day" aria-label="Tuesday"></div>
+        <div class="day" aria-label="Wednesday"></div>
+        <div class="day" aria-label="Thursday"></div>
+        <div class="day" aria-label="Friday"></div>
+        <div class="day" aria-label="Saturday"></div>
+      </div>
+    </div>
+  </main>
+  <div id="overlay" class="overlay" aria-hidden="true"></div>
+</th:block>
+
+<!-- script -->
+<th:block layout:fragment="script">
+  <script th:src="@{/js/responsive-calendar.js}"></script>
+</th:block>
+</html>


### PR DESCRIPTION
## Summary
- add responsive calendar controller
- implement mobile-first calendar template with sidebar
- style the layout with breakpoints and pastel buttons
- add JavaScript to handle sidebar with focus trap

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68621e8d93208327a7ca74e14661f115