### PR TITLE
Add mobile sidebar to dashboard

### DIFF
--- a/keep/src/main/resources/static/css/main/dashboard/mobile-sidebar.css
+++ b/keep/src/main/resources/static/css/main/dashboard/mobile-sidebar.css
@@ -1,0 +1,49 @@
+.mobile-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 250px;
+  height: 100%;
+  background: #fff;
+  box-shadow: 2px 0 6px rgba(0,0,0,0.1);
+  overflow-y: auto;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 120;
+}
+
+.mobile-sidebar.show {
+  transform: translateX(0);
+}
+
+.mobile-sidebar.hidden {
+  display: none;
+}
+
+.sidebar-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  margin: 0.5rem;
+}
+
+.sidebar-open {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+@media (max-width: 767px) {
+  .sidebar-open {
+    display: block;
+  }
+  .header-top {
+    display: none;
+  }
+  .mobile-sidebar .header-top {
+    display: block;
+  }
+}

--- a/keep/src/main/resources/static/js/mobile-sidebar.js
+++ b/keep/src/main/resources/static/js/mobile-sidebar.js
@@ -1,0 +1,43 @@
+(function() {
+  let placeholder;
+  document.addEventListener('DOMContentLoaded', function() {
+    const openBtn = document.getElementById('sidebar-open');
+    const container = document.getElementById('mobile-sidebar');
+    if (!openBtn || !container) {
+      return;
+    }
+    const closeBtn = container.querySelector('.sidebar-close');
+    const content = container.querySelector('.sidebar-content');
+    const header = document.querySelector('.header-top');
+
+    function open() {
+      if (!header || !content) return;
+      placeholder = document.createElement('div');
+      header.parentNode.insertBefore(placeholder, header);
+      content.appendChild(header);
+      container.classList.remove('hidden');
+      requestAnimationFrame(() => container.classList.add('show'));
+    }
+
+    function close() {
+      container.classList.remove('show');
+      container.addEventListener(
+        'transitionend',
+        () => {
+          if (placeholder && placeholder.parentNode) {
+            placeholder.parentNode.replaceChild(header, placeholder);
+            placeholder = null;
+          }
+          if (!container.querySelector('#location-sidebar.show')) {
+            container.classList.add('hidden');
+          }
+        },
+        { once: true }
+      );
+    }
+
+    openBtn.addEventListener('click', open);
+    closeBtn && closeBtn.addEventListener('click', close);
+    window.mobileSidebar = { open, close };
+  });
+})();

--- a/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
+++ b/keep/src/main/resources/templates/main/dashboard/dashboard-main.html
@@ -8,7 +8,8 @@
 <!--/* style */-->
 <th:block layout:fragment="add-css">
 	<link rel="stylesheet" th:href="@{/css/common/calendar.css}" />
-	<link rel="stylesheet" th:href="@{/css/main/dashboard/dashboard.css}" />
+        <link rel="stylesheet" th:href="@{/css/main/dashboard/dashboard.css}" />
+        <link rel="stylesheet" th:href="@{/css/main/dashboard/mobile-sidebar.css}" />
 <!-- dash.html head -->
 <link id="daily-css"  rel="stylesheet" th:href="@{/css/main/dashboard/components/dashboard-daily.css}"  disabled="false" />
 <link id="weekly-css" rel="stylesheet" th:href="@{/css/main/dashboard/components/dashboard-weekly.css}" disabled="true" />
@@ -22,7 +23,12 @@
 </th:block>
 <!--/* content */-->
 <th:block layout:fragment="content">
-	<div class="dashboard-header">
+        <!-- 1) 모바일 햄버거 토글 버튼 (≤767px 에서만 보임) -->
+        <button id="sidebar-open" class="sidebar-open">☰</button>
+
+        <!-- 2) 헤더 전체를 감싸는 wrapper (이걸 사이드바로 이동할 대상) -->
+        <div class="header-top">
+        <div class="dashboard-header">
                 <!-- 좌측: 일정 목록 선택 -->
                 <div class="dashboard-header-left">
                 목록 :
@@ -44,8 +50,16 @@
 			<button class="view-btn" data-view="weekly">주간</button>
 			<button class="view-btn" data-view="monthly">월간</button>
 <!-- 			<button class="view-btn" data-view="yearly">년간</button> -->
-		</div>
-	</div>
+                </div>
+        </div>
+        </div>
+
+        <!-- 3) 모바일 오프캔버스 사이드바 -->
+        <aside id="mobile-sidebar" class="mobile-sidebar hidden">
+          <!-- location-sidebar fragment 안에 .header-top 이 append 됩니다 -->
+          <button class="sidebar-close">×</button>
+          <div class="sidebar-content"></div>
+        </aside>
 	<div id="fragment-container"></div>
 	
 	<!-- 	daily.html 등록 모달 -->	
@@ -69,6 +83,7 @@
         <script th:src="@{/js/main/dashboard/components/modal/schedule-modal.js}"></script>
         <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
         <script th:src="@{/js/location-sidebar.js}"></script>
+        <script th:src="@{/js/mobile-sidebar.js}"></script>
         <script th:src="@{/js/main/common/toast.js}"></script>
         <script th:src="@{/js/main/dashboard/components/modal/monthly-more-modal.js}"></script>
 </th:block>


### PR DESCRIPTION
## Summary
- wrap dashboard header in `.header-top`
- add hamburger toggle and mobile sidebar container in dashboard-main.html
- include new CSS and JS files for mobile sidebar behavior

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686221f700708327accc13fff2f86a70